### PR TITLE
Check Python style using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: "python"
+
+python:
+   - "2.7"
+   - "3.3"
+   - "3.4"
+   - "3.5"
+   - "pypy"
+   - "pypy3"
+
+install:
+   - pip install flake8
+
+script:
+   - flake8 --ignore=W191,F401,E501 .
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
I have added a simple Travis CI config with checking Python style. Right now flake8 warns about these problems: W191,F401,E501. So these warnings were temporarily added to the ignore list. Do we want to fix them? :)

https://travis-ci.org/ligurio/testgres/builds/159972013