### PR TITLE
Providing hostname/ipaddress as parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import testgres
 node = None
 try:
     node = testgres.get_new_node('test').init().start()
-    print(node.execute('postgres', 'select 1'))
+    print(node.execute('postgres','127.0.0.1', 'select 1'))
 except testgres.ClusterException as e:
     print(e)
 finally:
@@ -66,7 +66,7 @@ Finally our temporary cluster is able to process queries. There are four ways to
 
 * `node.psql(database, query)` - runs query via `psql` command and returns tuple `(error code, stdout, stderr)`
 * `node.safe_psql(database, query)` - same as `psql()` except that it returns only `stdout`. If an error occures during the execution, an exception will be thrown.
-* `node.execute(database, query)` - connects to postgresql server using `psycopg2` or `pg8000` library (depends on which is installed in your system) and returns two-dimensional array with data.
+* `node.execute(database, host, query)` - connects to postgresql server using `psycopg2` or `pg8000` library (depends on which is installed in your system) and returns two-dimensional array with data.
 * `node.connect(database='postgres')` - returns connection wrapper (`NodeConnection`) capable of running several queries within a single transaction.
 
 The last one is the most powerful: you can use `begin(isolation_level)`, `commit()` and `rollback()`:

--- a/testgres/tests/test_simple.py
+++ b/testgres/tests/test_simple.py
@@ -15,7 +15,7 @@ class SimpleTest(unittest.TestCase):
 		node = get_new_node('test')
 		node.init()
 		node.start()
-		res = node.execute('postgres', 'select 1')
+		res = node.execute('postgres', '127.0.0.1', 'select 1')
 		self.assertEqual(len(res), 1)
 		self.assertEqual(res[0][0], 1)
 		node.stop()
@@ -32,7 +32,7 @@ class SimpleTest(unittest.TestCase):
 
 		replica.init_from_backup(node, 'my_backup', has_streaming=True)
 		replica.start()
-		res = replica.execute('postgres', 'select * from abc')
+		res = replica.execute('postgres', '127.0.0.1', 'select * from abc')
 		self.assertEqual(len(res), 1)
 		self.assertEqual(res[0], (1, 2))
 
@@ -46,7 +46,7 @@ class SimpleTest(unittest.TestCase):
 			% replica.name)
 		# time.sleep(0.5)
 		# Check that this record was exported to replica
-		res = replica.execute('postgres', 'select * from abc')
+		res = replica.execute('postgres', '127.0.0.1', 'select * from abc')
 		self.assertEqual(len(res), 2)
 		self.assertEqual(res[1], (3, 4))
 


### PR DESCRIPTION
We need this function for qa framework tasks. We cannot run qa automation tests only locally. Host param initialization needed for test execution on vms or remote hosts.