### PR TITLE
Add providing ipaddress to NodeConnection.

### DIFF
--- a/testgres/testgres.py
+++ b/testgres/testgres.py
@@ -70,9 +70,10 @@ class NodeConnection(object):
     Transaction wrapper returned by Node
     """
 
-    def __init__(self, parent_node, dbname, host="127.0.0.1", user=get_username(), password=None):
+    def __init__(self, parent_node, dbname, host="127.0.0.1", user=None, password=None):
         self.parent_node = parent_node
-
+        if user is None:
+            user = get_username()
         self.connection = pglib.connect(
             database=dbname,
             user=user,

--- a/testgres/testgres.py
+++ b/testgres/testgres.py
@@ -79,7 +79,7 @@ class NodeConnection(object):
             user=user,
             port=parent_node.port,
             host=host,
-            passwrod=password
+            password=password
         )
 
         self.cursor = self.connection.cursor()

--- a/testgres/testgres.py
+++ b/testgres/testgres.py
@@ -70,14 +70,15 @@ class NodeConnection(object):
     Transaction wrapper returned by Node
     """
 
-    def __init__(self, parent_node, dbname):
+    def __init__(self, parent_node, dbname, host="127.0.0.1", user=get_username(), password=None):
         self.parent_node = parent_node
 
         self.connection = pglib.connect(
             database=dbname,
-            user=get_username(),
+            user=user,
             port=parent_node.port,
-            host="127.0.0.1"
+            host=host,
+            passwrod=password
         )
 
         self.cursor = self.connection.cursor()


### PR DESCRIPTION
We need this feature for qa tasks because our test will run on remote servers or VMs.