### PR TITLE
Add pgbench init and pgbench command for node. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
     name='testgres',
     packages=['testgres'],
-    version='0.1.16',
+    version='0.1.17',
     description='Testing utility for postgresql and its extensions',
     author='Ildar Musin',
     author_email='zildermann@gmail.com',

--- a/testgres/testgres.py
+++ b/testgres/testgres.py
@@ -472,6 +472,42 @@ class PostgresNode(object):
 
             return backup_path
 
+    def pgbench_init(self, dbname='postgres', scale=1, options=[]):
+        """Prepare pgbench database"""
+        pgbench = self.get_bin_path("pgbench")
+        params = [
+            pgbench,
+            "-i",
+            "-s", "%i" % scale,
+            "-p",  "%i" % self.port,
+        ] + options + [dbname]
+        with open(self.output_filename, "a") as file_out, \
+                open(self.error_filename, "a") as file_err:
+            ret = subprocess.call(
+                params,
+                stdout=file_out,
+                stderr=file_err
+            )
+            if ret:
+                raise ClusterException("pgbench init failed")
+
+            return True
+
+    def pgbench(self, dbname='postgres', stdout=None, stderr=None, options=[]):
+        """Make pgbench process"""
+        pgbench = self.get_bin_path("pgbench")
+        params = [
+            pgbench,
+            "-p",  "%i" % self.port,
+        ] + options + [dbname]
+        proc = subprocess.Popen(
+            params,
+            stdout=stdout,
+            stderr=stderr
+        )
+
+        return proc
+
     def connect(self, dbname='postgres', username=None):
         return NodeConnection(parent_node=self, dbname=dbname, user=username)
 

--- a/testgres/testgres.py
+++ b/testgres/testgres.py
@@ -479,7 +479,7 @@ class PostgresNode(object):
             pgbench,
             "-i",
             "-s", "%i" % scale,
-            "-p",  "%i" % self.port,
+            "-p", "%i" % self.port
         ] + options + [dbname]
         with open(self.output_filename, "a") as file_out, \
                 open(self.error_filename, "a") as file_err:
@@ -498,7 +498,7 @@ class PostgresNode(object):
         pgbench = self.get_bin_path("pgbench")
         params = [
             pgbench,
-            "-p",  "%i" % self.port,
+            "-p", "%i" % self.port
         ] + options + [dbname]
         proc = subprocess.Popen(
             params,


### PR DESCRIPTION
Pgbench run as Popen for background tests. Example usage:
```python
node.pgbench_init()
pgbench = node.pgbench(
    stdout=subprocess.PIPE,
    stderr=subprocess.STDOUT,
    options=["-c", "4"])
pgbench.wait()
pgbench.stdout.close()
```