### PR TITLE
 Allow to feed smth into stdin of psql and safe_psql,  enable node restart logging

### DIFF
--- a/testgres/testgres.py
+++ b/testgres/testgres.py
@@ -776,7 +776,7 @@ class PostgresNode(object):
         _params = ["restart", "-D", self.data_dir, "-w"] + params
         _execute_utility("pg_ctl", _params,
                          self.utils_logname,
-                         write_to_pipe=False)
+                         write_to_pipe=True)
 
         return self
 

--- a/testgres/testgres.py
+++ b/testgres/testgres.py
@@ -845,7 +845,7 @@ class PostgresNode(object):
 
         return self
 
-    def psql(self, dbname, query=None, filename=None, username=None):
+    def psql(self, dbname, query=None, filename=None, username=None, inp=None):
         """
         Execute a query using psql.
 
@@ -881,14 +881,15 @@ class PostgresNode(object):
 
         # start psql process
         process = subprocess.Popen(psql_params,
+                                   stdin=subprocess.PIPE,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
 
         # wait until it finishes and get stdout and stderr
-        out, err = process.communicate()
+        out, err = process.communicate(input=inp)
         return process.returncode, out, err
 
-    def safe_psql(self, dbname, query, username=None):
+    def safe_psql(self, dbname, query, username=None, inp=None):
         """
         Execute a query using psql.
 
@@ -901,7 +902,7 @@ class PostgresNode(object):
             psql's output as str.
         """
 
-        ret, out, err = self.psql(dbname, query, username=username)
+        ret, out, err = self.psql(dbname, query, username=username, inp=inp)
         if ret:
             err = '' if not err else err.decode('utf-8')
             raise QueryException(err)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -105,12 +105,7 @@ class SimpleTest(unittest.TestCase):
             # check feeding input
             node.safe_psql('postgres', 'create table horns (w int)')
             node.safe_psql('postgres', 'copy horns from stdin (format csv)',
-                           input=
-b"""1
-2
-3
-\.
-""")
+                           input=b"1\n2\n3\n\.\n")
             sum = node.safe_psql('postgres', 'select sum(w) from horns')
             self.assertEqual(sum, b'6\n')
             node.safe_psql('postgres', 'drop table horns')

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -102,6 +102,19 @@ class SimpleTest(unittest.TestCase):
             res = node.safe_psql('postgres', 'select 1')
             self.assertEqual(res, b'1\n')
 
+            # check feeding input
+            node.safe_psql('postgres', 'create table horns (w int)')
+            node.safe_psql('postgres', 'copy horns from stdin (format csv)',
+                           input=
+b"""1
+2
+3
+\.
+""")
+            sum = node.safe_psql('postgres', 'select sum(w) from horns')
+            self.assertEqual(sum, b'6\n')
+            node.safe_psql('postgres', 'drop table horns')
+
             node.stop()
 
             # check psql on stopped node


### PR DESCRIPTION
1) Feeding data into `stdin` allows to test e.g. COPY FROM, see https://github.com/postgrespro/pg_shardman/commit/0f3866d6e7db820622480fa62a3abc5e748e965d#diff-9c0147891760ab4b5aea57c1d48e4ec0R311 for example
2) Is there a reason logging was disabled for pg_ctl restart?