### PR TITLE
make temp files deletion more robust

### DIFF
--- a/testgres/backup.py
+++ b/testgres/backup.py
@@ -171,5 +171,5 @@ class NodeBackup(object):
     def cleanup(self):
         if self._available:
             rmtree(self.base_dir, ignore_errors=True)
-            forget_temp_obj(self.base_dir)
+            forget_temp_obj(self.base_dir)  # small optimization
             self._available = False

--- a/testgres/backup.py
+++ b/testgres/backup.py
@@ -17,7 +17,7 @@ from .defaults import default_username
 
 from .exceptions import BackupException
 
-from .temp import mk_temp_dir, forget_temp_obj
+from .temp import mk_temp_dir
 
 from .utils import \
     get_bin_path, \
@@ -171,5 +171,4 @@ class NodeBackup(object):
     def cleanup(self):
         if self._available:
             rmtree(self.base_dir, ignore_errors=True)
-            forget_temp_obj(self.base_dir)  # small optimization
             self._available = False

--- a/testgres/backup.py
+++ b/testgres/backup.py
@@ -1,12 +1,9 @@
 # coding: utf-8
 
 import os
-import shutil
 
+from shutil import rmtree, copytree
 from six import raise_from
-from tempfile import mkdtemp
-
-from .config import testgres_config
 
 from .consts import \
     DATA_DIR, \
@@ -19,6 +16,8 @@ from .consts import \
 from .defaults import default_username
 
 from .exceptions import BackupException
+
+from .temp import mk_temp_dir, forget_temp_obj
 
 from .utils import \
     get_bin_path, \
@@ -55,8 +54,7 @@ class NodeBackup(object):
         # yapf: disable
         # Set default arguments
         username = username or default_username()
-        base_dir = base_dir or mkdtemp(prefix=TMP_BACKUP,
-                                       dir=testgres_config.temp_dir)
+        base_dir = base_dir or mk_temp_dir(TMP_BACKUP)
 
         # public
         self.original_node = node
@@ -103,15 +101,14 @@ class NodeBackup(object):
         available = not destroy
 
         if available:
-            dest_base_dir = mkdtemp(prefix=TMP_NODE,
-                                    dir=testgres_config.temp_dir)
+            dest_base_dir = mk_temp_dir(TMP_NODE)
 
             data1 = os.path.join(self.base_dir, DATA_DIR)
             data2 = os.path.join(dest_base_dir, DATA_DIR)
 
             try:
                 # Copy backup to new data dir
-                shutil.copytree(data1, data2)
+                copytree(data1, data2)
             except Exception as e:
                 raise_from(BackupException('Failed to copy files'), e)
         else:
@@ -140,8 +137,7 @@ class NodeBackup(object):
 
         # Build a new PostgresNode
         from .node import PostgresNode
-        node = PostgresNode(name=name,
-                            base_dir=base_dir)
+        node = PostgresNode(name=name, base_dir=base_dir)
 
         # New nodes should always remove dir tree
         node._should_rm_dirs = True
@@ -164,8 +160,7 @@ class NodeBackup(object):
         """
 
         # Build a new PostgresNode
-        node = self.spawn_primary(name=name,
-                                  destroy=destroy)
+        node = self.spawn_primary(name=name, destroy=destroy)
 
         # Assign it a master and a recovery file (private magic)
         node._assign_master(self.original_node)
@@ -175,5 +170,6 @@ class NodeBackup(object):
 
     def cleanup(self):
         if self._available:
-            shutil.rmtree(self.base_dir, ignore_errors=True)
+            rmtree(self.base_dir, ignore_errors=True)
+            forget_temp_obj(self.base_dir)
             self._available = False

--- a/testgres/cache.py
+++ b/testgres/cache.py
@@ -2,8 +2,8 @@
 
 import io
 import os
-import shutil
 
+from shutil import copytree
 from six import raise_from
 
 from .config import testgres_config
@@ -46,7 +46,7 @@ def cached_initdb(data_dir, logfile=None, params=None):
 
         try:
             # Copy cached initdb to current data dir
-            shutil.copytree(cached_data_dir, data_dir)
+            copytree(cached_data_dir, data_dir)
 
             # Assign this node a unique system id if asked to
             if testgres_config.cached_initdb_unique:

--- a/testgres/connection.py
+++ b/testgres/connection.py
@@ -17,7 +17,6 @@ from enum import Enum
 
 from .exceptions import QueryException
 
-
 # export these exceptions
 InternalError = pglib.InternalError
 ProgrammingError = pglib.ProgrammingError

--- a/testgres/consts.py
+++ b/testgres/consts.py
@@ -9,6 +9,7 @@ TMP_NODE = 'tgsn_'
 TMP_DUMP = 'tgsd_'
 TMP_CACHE = 'tgsc_'
 TMP_BACKUP = 'tgsb_'
+TMP_DEFAULT = 'tgs_'
 
 # path to control file
 XLOG_CONTROL_FILE = "global/pg_control"

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -2,14 +2,13 @@
 
 import io
 import os
-import shutil
 import six
 import subprocess
 import time
 
 from enum import Enum
+from shutil import rmtree
 from six import raise_from
-from tempfile import mkstemp, mkdtemp
 
 from .cache import cached_initdb
 
@@ -49,6 +48,11 @@ from .exceptions import \
     TimeoutException
 
 from .logger import TestgresLogger
+
+from .temp import \
+    mk_temp_dir, \
+    mk_temp_file, \
+    forget_temp_obj
 
 from .utils import \
     eprint, \
@@ -203,8 +207,7 @@ class PostgresNode(object):
 
     def _prepare_dirs(self):
         if not self.base_dir:
-            self.base_dir = mkdtemp(prefix=TMP_NODE,
-                                    dir=testgres_config.temp_dir)
+            self.base_dir = mk_temp_dir(TMP_NODE)
 
         if not os.path.exists(self.base_dir):
             os.makedirs(self.base_dir)
@@ -613,7 +616,8 @@ class PostgresNode(object):
         else:
             rm_dir = self.data_dir    # just data, save logs
 
-        shutil.rmtree(rm_dir, ignore_errors=True)
+        rmtree(rm_dir, ignore_errors=True)
+        forget_temp_obj(self.base_dir)  # unregister topmost dir!
 
         return self
 
@@ -710,15 +714,10 @@ class PostgresNode(object):
             Path to a file containing dump.
         """
 
-        def tmpfile():
-            fd, fname = mkstemp(prefix=TMP_DUMP, dir=testgres_config.temp_dir)
-            os.close(fd)
-            return fname
-
         # Set default arguments
         dbname = dbname or default_dbname()
         username = username or default_username()
-        filename = filename or tmpfile()
+        filename = filename or mk_temp_file(TMP_DUMP, delete=False)
 
         # yapf: disable
         _params = [

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -126,6 +126,7 @@ class PostgresNode(object):
         if c1 or c2:
             self.cleanup(attempts)
         else:
+            forget_temp_obj(self.base_dir)    # preserve files!
             self._try_shutdown(attempts)
 
     @property

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -616,9 +616,9 @@ class PostgresNode(object):
             rm_dir = self.base_dir    # everything
         else:
             rm_dir = self.data_dir    # just data, save logs
+            forget_temp_obj(self.base_dir)    # preserve files!
 
         rmtree(rm_dir, ignore_errors=True)
-        forget_temp_obj(self.base_dir)  # unregister topmost dir!
 
         return self
 

--- a/testgres/temp.py
+++ b/testgres/temp.py
@@ -59,6 +59,9 @@ def mk_temp_dir(prefix=TMP_DEFAULT, delete=True):
 @atexit.register
 def _rm_temp():
     for f in temp_files:
+        if not os.path.exists(f):
+            continue
+
         if os.path.isdir(f):
             rmtree(f, ignore_errors=True)
         if os.path.isfile(f):

--- a/testgres/temp.py
+++ b/testgres/temp.py
@@ -1,0 +1,65 @@
+import atexit
+import os
+import tempfile
+
+from shutil import rmtree
+
+from .consts import TMP_DEFAULT
+
+temp_files = set()
+
+
+def set_temp_root(path):
+    """
+    Set a root dir for temporary files.
+    """
+
+    tempfile.tempdir = path
+
+
+def get_temp_root():
+    """
+    Get current root dir for temporary files.
+    """
+
+    return tempfile.tempdir
+
+
+def forget_temp_obj(path):
+    """
+    Do not remove a file or dir if it's provided by this module.
+    """
+
+    temp_files.discard(path)
+
+
+def mk_temp_file(prefix=TMP_DEFAULT, delete=True):
+    """
+    Provide a temporary file.
+    """
+
+    fd, fname = tempfile.mkstemp(prefix=prefix)
+    os.close(fd)
+    if delete:
+        temp_files.add(fname)
+    return fname
+
+
+def mk_temp_dir(prefix=TMP_DEFAULT, delete=True):
+    """
+    Provide a temporary directory.
+    """
+
+    dname = tempfile.mkdtemp(prefix=prefix)
+    if delete:
+        temp_files.add(dname)
+    return dname
+
+
+@atexit.register
+def _rm_temp():
+    for f in temp_files:
+        if os.path.isdir(f):
+            rmtree(f, ignore_errors=True)
+        if os.path.isfile(f):
+            os.remove(f)

--- a/testgres/utils.py
+++ b/testgres/utils.py
@@ -14,7 +14,6 @@ from distutils.version import LooseVersion
 from .config import testgres_config
 from .exceptions import ExecUtilException
 
-
 # rows returned by PG_CONFIG
 _pg_config_data = {}
 
@@ -38,7 +37,7 @@ def release_port(port):
     Free port provided by reserve_port().
     """
 
-    bound_ports.remove(port)
+    bound_ports.discard(port)
 
 
 def execute_utility(args, logfile=None):


### PR DESCRIPTION
This patch introduces 3 important functions:

* `mk_temp_dir()`
* `mk_temp_file()`
* `forget_temp_file()`

The first two of them create a new file/dir and add them to a `set()` of files to be removed at process exit. The latter should be called by a `PostgresNode` which wants to preserve its `base_dir`.