### PR TITLE
Add PostgresNode.__repr__() method

### DIFF
--- a/testgres/api.py
+++ b/testgres/api.py
@@ -7,27 +7,27 @@ This module was created under influence of Postgres TAP test feature
 edit configuration files, start/stop cluster, execute queries. The
 typical flow may look like:
 
->>> with get_new_node('test') as node:
+>>> with get_new_node() as node:
 ...     node.init().start()
 ...     result = node.safe_psql('postgres', 'select 1')
 ...     print(result.decode('utf-8').strip())
 ...     node.stop()
-PostgresNode('test', port=..., base_dir=...)
+PostgresNode(name='...', port=..., base_dir='...')
 1
-PostgresNode('test', port=..., base_dir=...)
+PostgresNode(name='...', port=..., base_dir='...')
 
     Or:
 
->>> with get_new_node('master') as master:
+>>> with get_new_node() as master:
 ...     master.init().start()
 ...     with master.backup() as backup:
-...         with backup.spawn_replica('replica') as replica:
+...         with backup.spawn_replica() as replica:
 ...             replica = replica.start()
 ...             master.execute('postgres', 'create table test (val int4)')
 ...             master.execute('postgres', 'insert into test values (0), (1), (2)')
 ...             replica.catchup()  # wait until changes are visible
 ...             print(replica.execute('postgres', 'select count(*) from test'))
-PostgresNode('master', port=..., base_dir=...)
+PostgresNode(name='...', port=..., base_dir='...')
 [(3,)]
 
 Copyright (c) 2016, Postgres Professional

--- a/testgres/api.py
+++ b/testgres/api.py
@@ -7,27 +7,27 @@ This module was created under influence of Postgres TAP test feature
 edit configuration files, start/stop cluster, execute queries. The
 typical flow may look like:
 
->>> with get_new_node() as node:
+>>> with get_new_node('test') as node:
 ...     node.init().start()
 ...     result = node.safe_psql('postgres', 'select 1')
 ...     print(result.decode('utf-8').strip())
 ...     node.stop()
-<testgres.node.PostgresNode object at 0x...>
+PostgresNode('test', port=..., base_dir=...)
 1
-<testgres.node.PostgresNode object at 0x...>
+PostgresNode('test', port=..., base_dir=...)
 
     Or:
 
->>> with get_new_node() as master:
+>>> with get_new_node('master') as master:
 ...     master.init().start()
 ...     with master.backup() as backup:
-...         with backup.spawn_replica() as replica:
+...         with backup.spawn_replica('replica') as replica:
 ...             replica = replica.start()
 ...             master.execute('postgres', 'create table test (val int4)')
 ...             master.execute('postgres', 'insert into test values (0), (1), (2)')
 ...             replica.catchup()  # wait until changes are visible
 ...             print(replica.execute('postgres', 'select count(*) from test'))
-<testgres.node.PostgresNode object at 0x...>
+PostgresNode('master', port=..., base_dir=...)
 [(3,)]
 
 Copyright (c) 2016, Postgres Professional

--- a/testgres/config.py
+++ b/testgres/config.py
@@ -152,9 +152,11 @@ def scoped_config(**options):
     Temporarily set custom GlobalConfig options for this context.
 
     Example:
+        >>> from .api import get_new_node
         >>> with scoped_config(cache_initdb=False):
         ...     with get_new_node().init().start() as node:
         ...         print(node.execute('select 1'))
+        [(1,)]
     """
 
     try:

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -136,8 +136,8 @@ class PostgresNode(object):
             self._try_shutdown(attempts)
 
     def __repr__(self):
-        return "PostgresNode(name='{}', port={}, base_dir='{}')".format(
-            self.name, self.port, self.base_dir)
+        return "{}(name='{}', port={}, base_dir='{}')".format(
+            self.__class__.__name__, self.name, self.port, self.base_dir)
 
     @property
     def pid(self):

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -136,7 +136,7 @@ class PostgresNode(object):
             self._try_shutdown(attempts)
 
     def __repr__(self):
-        return "PostgresNode('{}', port={}, base_dir={})".format(
+        return "PostgresNode(name='{}', port={}, base_dir='{}')".format(
             self.name, self.port, self.base_dir)
 
     @property

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -135,6 +135,10 @@ class PostgresNode(object):
         else:
             self._try_shutdown(attempts)
 
+    def __repr__(self):
+        return "PostgresNode('{}', port={}, base_dir={})".format(
+            self.name, self.port, self.base_dir)
+
     @property
     def pid(self):
         """

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 import os
+import re
 import subprocess
 import tempfile
 import testgres
@@ -70,6 +71,11 @@ def removing(f):
 
 
 class TestgresTests(unittest.TestCase):
+    def test_node_repr(self):
+        with get_new_node() as node:
+            pattern = 'PostgresNode\(name=\'.+\', port=.+, base_dir=\'.+\'\)'
+            self.assertIsNotNone(re.match(pattern, str(node)))
+
     def test_custom_init(self):
         with get_new_node() as node:
             # enable page checksums


### PR DESCRIPTION
Because current string representation of `PostgresNode` doesn't make much sense. Now it looks something like:
```
PostgresNode('test', port=26144, base_dir=/tmp/tgsn_LsaCM1)
```
Also fixed some examples in comments so that they pass `doctest`.