### PR TITLE
add 'suppress' to PostgresNode.poll_query_until() to mute exceptions

### DIFF
--- a/testgres/__init__.py
+++ b/testgres/__init__.py
@@ -10,8 +10,10 @@ from .config import \
 
 from .connection import \
     NodeConnection, \
+    DatabaseError, \
     InternalError, \
-    ProgrammingError
+    ProgrammingError, \
+    OperationalError
 
 from .exceptions import *
 from .enums import *

--- a/testgres/connection.py
+++ b/testgres/connection.py
@@ -17,9 +17,11 @@ from .defaults import \
 
 from .exceptions import QueryException
 
-# export these exceptions
+# export some exceptions
+DatabaseError = pglib.DatabaseError
 InternalError = pglib.InternalError
 ProgrammingError = pglib.ProgrammingError
+OperationalError = pglib.OperationalError
 
 
 class NodeConnection(object):

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -19,10 +19,7 @@ from .cache import cached_initdb
 
 from .config import testgres_config
 
-from .connection import \
-    NodeConnection, \
-    InternalError,  \
-    ProgrammingError
+from .connection import NodeConnection
 
 from .consts import \
     DATA_DIR, \
@@ -531,10 +528,10 @@ class PostgresNode(object):
             This instance of :class:`.PostgresNode`.
 
         Examples:
-            append_conf(fsync=False)
-            append_conf('log_connections = yes')
-            append_conf(random_page_cost=1.5, fsync=True, ...)
-            append_conf('postgresql.conf', 'synchronous_commit = off')
+            >>> append_conf(fsync=False)
+            >>> append_conf('log_connections = yes')
+            >>> append_conf(random_page_cost=1.5, fsync=True, ...)
+            >>> append_conf('postgresql.conf', 'synchronous_commit = off')
         """
 
         lines = [line]
@@ -970,8 +967,7 @@ class PostgresNode(object):
                          sleep_time=1,
                          expected=True,
                          commit=True,
-                         raise_programming_error=True,
-                         raise_internal_error=True):
+                         suppress=None):
         """
         Run a query once per second until it returns 'expected'.
         Query should return a single value (1 row, 1 column).
@@ -984,13 +980,13 @@ class PostgresNode(object):
             sleep_time: how much should we sleep after a failure?
             expected: what should be returned to break the cycle?
             commit: should (possible) changes be committed?
-            raise_programming_error: enable ProgrammingError?
-            raise_internal_error: enable InternalError?
+            suppress: a collection of exceptions to be suppressed.
 
         Examples:
-            poll_query_until('select true')
-            poll_query_until('postgres', "select now() > '01.01.2018'")
-            poll_query_until('select false', expected=True, max_attempts=4)
+            >>> poll_query_until('select true')
+            >>> poll_query_until('postgres', "select now() > '01.01.2018'")
+            >>> poll_query_until('select false', expected=True, max_attempts=4)
+            >>> poll_query_until('select 1', suppress={testgres.OperationalError})
         """
 
         # sanity checks
@@ -1022,13 +1018,8 @@ class PostgresNode(object):
                 elif expected is None:
                     return    # done
 
-            except ProgrammingError as e:
-                if raise_programming_error:
-                    raise e
-
-            except InternalError as e:
-                if raise_internal_error:
-                    raise e
+            except tuple(suppress or []):
+                pass    # we're suppressing them
 
             time.sleep(sleep_time)
             attempts += 1
@@ -1219,13 +1210,14 @@ class PostgresNode(object):
             options: additional options for pgbench (list).
 
             **kwargs: named options for pgbench.
-                Examples:
-                    pgbench_run(initialize=True, scale=2)
-                    pgbench_run(time=10)
                 Run pgbench --help to learn more.
 
         Returns:
             Stdout produced by pgbench.
+
+        Examples:
+            >>> pgbench_run(initialize=True, scale=2)
+            >>> pgbench_run(time=10)
         """
 
         # Set default arguments

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -625,7 +625,7 @@ class TestgresTests(unittest.TestCase):
                     query='dummy2',
                     max_attempts=3,
                     sleep_time=0.01,
-                    raise_programming_error=False)
+                    suppress={testgres.ProgrammingError})
 
             # check 1 arg, ok
             node.poll_query_until('select true')


### PR DESCRIPTION
This is an alternative approach to the problem covered by PR #50.

The idea is to provide a set of `suppress`ed exceptions to `poll_query_until`.