### PR TITLE
Fix some bugs with pipe on Windows

### DIFF
--- a/testgres/node.py
+++ b/testgres/node.py
@@ -865,8 +865,7 @@ class PostgresNode(object):
             "-X",  # no .psqlrc
             "-A",  # unaligned output
             "-t",  # print rows only
-            "-q",  # run quietly
-            dbname
+            "-q"  # run quietly
         ]  # yapf: disable
 
         # set variables before execution
@@ -880,6 +879,9 @@ class PostgresNode(object):
             psql_params.extend(("-f", filename))
         else:
             raise QueryException('Query or filename must be provided')
+
+        # should be the last one
+        psql_params.append(dbname)
 
         # start psql process
         process = subprocess.Popen(


### PR DESCRIPTION
In some cases on Windows, the process.communicate() function does not return any results.
For example, subprocess.Popen() runs "pg_ctl start" which starts "postgres". The process.communicate() function then waits for "postgres" to exit, not just "pg_ctl".
Using write to a temporary file instead of PIPE in execute_utility() works correctly.
