### PR TITLE
Expose the execute_utility function

### DIFF
--- a/testgres/__init__.py
+++ b/testgres/__init__.py
@@ -25,7 +25,8 @@ from .utils import \
     bound_ports, \
     get_bin_path, \
     get_pg_config, \
-    get_pg_version
+    get_pg_version, \
+    execute_utility
 
 from .standby import \
     First, \


### PR DESCRIPTION
This function should be exposed in the package to be able to reuse it when there is a need to run commands in tests like e.g. this: https://github.com/postgrespro/pg_probackup/blob/22c808312f67a060cda3bb36e5a032784a5810f9/tests/helpers/ptrack_helpers.py#L98