### PR TITLE
Change method for getting default user name, some sudo versions unexcepted working with getpass 

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM postgres:${PG_VERSION}-alpine
+FROM postgres:${PG_VERSION}-alpine3.14
 
 ENV PYTHON=python${PYTHON_VERSION}
 RUN if [ "${PYTHON_VERSION}" = "2" ] ; then \

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -27,9 +27,8 @@ $PIP install coverage flake8 psutil Sphinx sphinxcontrib-napoleon
 # install testgres' dependencies
 export PYTHONPATH=$(pwd)
 $PIP install .
-
 # test code quality
-flake8 .
+flake8 --ignore=F401,E501,F403 .
 
 
 # remove existing coverage file
@@ -68,3 +67,4 @@ set +eux
 
 # send coverage stats to Codecov
 bash <(curl -s https://codecov.io/bash)
+bash

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -67,4 +67,3 @@ set +eux
 
 # send coverage stats to Codecov
 bash <(curl -s https://codecov.io/bash)
-bash

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -28,7 +28,7 @@ $PIP install coverage flake8 psutil Sphinx sphinxcontrib-napoleon
 export PYTHONPATH=$(pwd)
 $PIP install .
 # test code quality
-flake8 --ignore=F401,E501,F403 .
+flake8 .
 
 
 # remove existing coverage file

--- a/testgres/defaults.py
+++ b/testgres/defaults.py
@@ -1,5 +1,4 @@
 import datetime
-import getpass
 import os
 import struct
 import uuid
@@ -18,7 +17,7 @@ def default_username():
     Return default username (current user).
     """
 
-    return getpass.getuser()
+    return os.getlogin()
 
 
 def generate_app_name():

--- a/testgres/defaults.py
+++ b/testgres/defaults.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import pwd
 import struct
 import uuid
 
@@ -17,7 +18,7 @@ def default_username():
     Return default username (current user).
     """
 
-    return os.getlogin()
+    return pwd.getpwuid(os.getuid())[0]
 
 
 def generate_app_name():


### PR DESCRIPTION
For example sudo version 1.8.25p1:
[root@centos-8 ~]# sudo -u test sh -c 'python3 -c "import getpass; print(getpass.getuser())"';
root
[root@centos-8 ~]# sudo -u test sh -c 'python3 -c "import os; print(os.getlogin())"';
test
