### PR TITLE
Catch FileNotFoundError exception

### DIFF
--- a/testgres/enums.py
+++ b/testgres/enums.py
@@ -1,5 +1,6 @@
 from enum import Enum, IntEnum
 from six import iteritems
+from psutil import NoSuchProcess
 
 
 class XLogMethod(Enum):
@@ -68,11 +69,15 @@ class ProcessType(Enum):
             ],
         }  # yapf: disable
 
+        try:
+            cmdline = ''.join(process.cmdline())
+        except (FileNotFoundError, ProcessLookupError, NoSuchProcess):
+            return ProcessType.Unknown
+
         # we deliberately cut special words and spaces
-        cmdline = ''.join(process.cmdline()) \
-                    .replace('postgres:', '', 1) \
-                    .replace('bgworker:', '', 1) \
-                    .replace(' ', '')
+        cmdline = cmdline.replace('postgres:', '', 1) \
+            .replace('bgworker:', '', 1) \
+            .replace(' ', '')
 
         for ptype in ProcessType:
             if cmdline.startswith(ptype.value.replace(' ', '')):


### PR DESCRIPTION
When we want to find some Postgres process in testgres psutils lib first gets list of all system processes (children() function in testgres's auxiliary_processes). Next testgres asks for process name (cmdline() function), so psutils goes to /proc/pid/ in Linux. In case any of processes listed in previous step, we get FileNotFoundError