### PR TITLE
Remove unnecessary output

### DIFF
--- a/testgres/connection.py
+++ b/testgres/connection.py
@@ -110,8 +110,7 @@ class NodeConnection(object):
                 res = [tuple(t) for t in res]
 
             return res
-        except Exception as e:
-            print("Error executing query: {}".format(e))
+        except Exception:
             return None
 
     def close(self):


### PR DESCRIPTION
For example, this script
```py
#!/usr/bin/env python3
# coding: utf-8

import testgres

node = testgres.get_new_node()
node.init()
node.start()
node.safe_psql("CREATE TABLE IF NOT EXISTS o_test (val int);")
node.execute("INSERT INTO o_test VALUES (1);")
print(node.execute("TABLE o_test;")[0][0])
node.execute("UPDATE o_test SET val = 2;")
print(node.execute("TABLE o_test;")[0][0])
node.stop()
```
prints
```
python t/checkpointer_test.py
Error executing query: attempting to use unexecuted cursor
1
Error executing query: attempting to use unexecuted cursor
2
```
This is probably not the intended behavior