### PR TITLE
fix locale warning

### DIFF
--- a/testgres/operations/os_ops.py
+++ b/testgres/operations/os_ops.py
@@ -20,7 +20,9 @@ class ConnectionParams:
 
 
 def get_default_encoding():
-    return locale.getdefaultlocale()[1] or 'UTF-8'
+    if not hasattr(locale, 'getencoding'):
+        locale.getencoding = locale.getpreferredencoding
+    return locale.getencoding() or 'UTF-8'
 
 
 class OsOperations:


### PR DESCRIPTION
DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead. 
Исправил заменив на getlocale