### PR TITLE
Add PG_PROBACKUP_WAL_TREE_ENABLED env param

### DIFF
--- a/testgres/plugins/pg_probackup2/pg_probackup2/app.py
+++ b/testgres/plugins/pg_probackup2/pg_probackup2/app.py
@@ -54,6 +54,7 @@ class ProbackupApp:
         self.probackup_path = probackup_path or init_params.probackup_path
         self.probackup_old_path = init_params.probackup_old_path
         self.remote = init_params.remote
+        self.wal_tree_enabled = init_params.wal_tree_enabled
         self.verbose = init_params.verbose
         self.archive_compress = init_params.archive_compress
         self.test_class.output = None
@@ -184,6 +185,9 @@ class ProbackupApp:
             options = options + [
                 '--remote-proto=ssh',
                 '--remote-host=localhost']
+
+        if self.wal_tree_enabled:
+            options = options + ['--wal-tree']
 
         return self.run(cmd + options, old_binary=old_binary, expect_error=expect_error)
 

--- a/testgres/plugins/pg_probackup2/pg_probackup2/init_helpers.py
+++ b/testgres/plugins/pg_probackup2/pg_probackup2/init_helpers.py
@@ -170,6 +170,7 @@ class Init(object):
 
         self.remote = test_env.get('PGPROBACKUP_SSH_REMOTE', None) == 'ON'
         self.ptrack = test_env.get('PG_PROBACKUP_PTRACK', None) == 'ON' and self.pg_config_version >= 110000
+        self.wal_tree_enabled = test_env.get('PG_PROBACKUP_WAL_TREE_ENABLED', None) == 'ON'
 
         self.paranoia = test_env.get('PG_PROBACKUP_PARANOIA', None) == 'ON'
         env_compress = test_env.get('ARCHIVE_COMPRESSION', None)


### PR DESCRIPTION
PG_PROBACKUP_WAL_TREE_ENABLED used to set to probackup setting when creating instance how wals should be located