### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ with testgres.get_new_node() as node:
 # ... node stops and its files are about to be removed
 ```
 
-There are four API methods for runnig queries:
+There are four API methods for running queries:
 
 | Command | Description |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `node.psql(query, ...)` | Runs query via `psql` command and returns tuple `(error code, stdout, stderr)`. |
-| `node.safe_psql(query, ...)` | Same as `psql()` except that it returns only `stdout`. If an error occures during the execution, an exception will be thrown. |
+| `node.safe_psql(query, ...)` | Same as `psql()` except that it returns only `stdout`. If an error occurs during the execution, an exception will be thrown. |
 | `node.execute(query, ...)` | Connects to PostgreSQL using `psycopg2` or `pg8000` (depends on which one is installed in your system) and returns two-dimensional array with data. |
 | `node.connect(dbname, ...)` | Returns connection wrapper (`NodeConnection`) capable of running several queries within a single transaction. |
 

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1143,7 +1143,7 @@ class PostgresNode(object):
             filename
         ]  # yapf: disable
 
-        # try pg_restore if dump is binary formate, and psql if not
+        # try pg_restore if dump is binary format, and psql if not
         try:
             execute_utility(_params, self.utils_log_name)
         except ExecUtilException:
@@ -1286,7 +1286,7 @@ class PostgresNode(object):
 
         Args:
             standbys: either :class:`.First` or :class:`.Any` object specifying
-                sychronization parameters or just a plain list of
+                synchronization parameters or just a plain list of
                 :class:`.PostgresNode`s replicas which would be equivalent
                 to passing ``First(1, <list>)``. For PostgreSQL 9.5 and below
                 it is only possible to specify a plain list of standbys as

--- a/testgres/plugins/pg_probackup2/pg_probackup2/gdb.py
+++ b/testgres/plugins/pg_probackup2/pg_probackup2/gdb.py
@@ -37,7 +37,7 @@ class GDBobj:
                                    " to run GDB tests")
             raise GdbException("No gdb usage possible.")
 
-        # Check gdb presense
+        # Check gdb presence
         try:
             gdb_version, _ = subprocess.Popen(
                 ['gdb', '--version'],

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -501,7 +501,7 @@ class TestgresTests(unittest.TestCase):
             sub.disable()
             node1.safe_psql('insert into test values (3, 3)')
 
-            # enable and ensure that data successfully transfered
+            # enable and ensure that data successfully transferred
             sub.enable()
             sub.catchup()
             res = node2.execute('select * from test')
@@ -509,7 +509,7 @@ class TestgresTests(unittest.TestCase):
 
             # Add new tables. Since we added "all tables" to publication
             # (default behaviour of publish() method) we don't need
-            # to explicitely perform pub.add_tables()
+            # to explicitly perform pub.add_tables()
             create_table = 'create table test2 (c char)'
             node1.safe_psql(create_table)
             node2.safe_psql(create_table)
@@ -526,7 +526,7 @@ class TestgresTests(unittest.TestCase):
             pub.drop()
 
             # create new publication and subscription for specific table
-            # (ommitting copying data as it's already done)
+            # (omitting copying data as it's already done)
             pub = node1.publish('newpub', tables=['test'])
             sub = node2.subscribe(pub, 'newsub', copy_data=False)
 
@@ -535,7 +535,7 @@ class TestgresTests(unittest.TestCase):
             res = node2.execute('select * from test')
             self.assertListEqual(res, [(1, 1), (2, 2), (3, 3), (4, 4)])
 
-            # explicitely add table
+            # explicitly add table
             with self.assertRaises(ValueError):
                 pub.add_tables([])    # fail
             pub.add_tables(['test2'])

--- a/tests/test_simple_remote.py
+++ b/tests/test_simple_remote.py
@@ -480,7 +480,7 @@ class TestgresRemoteTests(unittest.TestCase):
             sub.disable()
             node1.safe_psql('insert into test values (3, 3)')
 
-            # enable and ensure that data successfully transfered
+            # enable and ensure that data successfully transferred
             sub.enable()
             sub.catchup()
             res = node2.execute('select * from test')
@@ -488,7 +488,7 @@ class TestgresRemoteTests(unittest.TestCase):
 
             # Add new tables. Since we added "all tables" to publication
             # (default behaviour of publish() method) we don't need
-            # to explicitely perform pub.add_tables()
+            # to explicitly perform pub.add_tables()
             create_table = 'create table test2 (c char)'
             node1.safe_psql(create_table)
             node2.safe_psql(create_table)
@@ -505,7 +505,7 @@ class TestgresRemoteTests(unittest.TestCase):
             pub.drop()
 
             # create new publication and subscription for specific table
-            # (ommitting copying data as it's already done)
+            # (omitting copying data as it's already done)
             pub = node1.publish('newpub', tables=['test'])
             sub = node2.subscribe(pub, 'newsub', copy_data=False)
 
@@ -514,7 +514,7 @@ class TestgresRemoteTests(unittest.TestCase):
             res = node2.execute('select * from test')
             self.assertListEqual(res, [(1, 1), (2, 2), (3, 3), (4, 4)])
 
-            # explicitely add table
+            # explicitly add table
             with self.assertRaises(ValueError):
                 pub.add_tables([])  # fail
             pub.add_tables(['test2'])


### PR DESCRIPTION
Found via `codespell -L splitted`