### PR TITLE
Fix set_auto_conf with single quotes

### DIFF
--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1634,7 +1634,7 @@ class PostgresNode(object):
             current_options[name] = var
 
         for option in options:
-            assert type(option) == str
+            assert type(option) == str  # noqa: E721
             assert option != ""
             assert option.strip() == option
 
@@ -1699,7 +1699,7 @@ class PostgresNode(object):
         return bin_path
 
     def _escape_config_value(value):
-        assert type(value) == str
+        assert type(value) == str  # noqa: E721
 
         result = "'"
 

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1704,17 +1704,17 @@ class PostgresNode(object):
         result = "'"
 
         for ch in value:
-            if (ch == "'"):
+            if ch == "'":
                 result += "\\'"
-            elif (ch == "\n"):
+            elif ch == "\n":
                 result += "\\n"
-            elif (ch == "\r"):
+            elif ch == "\r":
                 result += "\\r"
-            elif (ch == "\t"):
+            elif ch == "\t":
                 result += "\\t"
-            elif (ch == "\b"):
+            elif ch == "\b":
                 result += "\\b"
-            elif (ch == "\\"):
+            elif ch == "\\":
                 result += "\\\\"
             else:
                 result += ch

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1634,6 +1634,10 @@ class PostgresNode(object):
             current_options[name] = var
 
         for option in options:
+            assert type(option) == str
+            assert option != ""
+            assert option.strip() == option
+
             value = options[option]
             valueType = type(value)
 
@@ -1695,6 +1699,8 @@ class PostgresNode(object):
         return bin_path
 
     def _escape_config_value(value):
+        assert type(value) == str
+
         result = "'"
 
         for ch in value:

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1627,17 +1627,22 @@ class PostgresNode(object):
             name, var = line.partition('=')[::2]
             name = name.strip()
             var = var.strip()
-            var = var.strip('"')
-            var = var.strip("'")
 
-            # remove options specified in rm_options list
+            # Handle quoted values and remove escaping
+            if var.startswith("'") and var.endswith("'"):
+                var = var[1:-1].replace("''", "'")
+
+            # Remove options specified in rm_options list
             if name in rm_options:
                 continue
 
             current_options[name] = var
 
         for option in options:
-            current_options[option] = options[option]
+            value = options[option]
+            if isinstance(value, str):
+                value = value.replace("'", "\\'")
+            current_options[option] = value
 
         auto_conf = ''
         for option in current_options:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1061,6 +1061,33 @@ class TestgresTests(unittest.TestCase):
         except FileNotFoundError:
             pass  # Expected error
 
+    def test_set_auto_conf(self):
+        with get_new_node() as node:
+            node.init().start()
+
+            options = {
+                "archive_command": "cp '%p' \"/mnt/server/archivedir/%f\"",
+                'restore_command': 'cp "/mnt/server/archivedir/%f" \'%p\'',
+            }
+
+            node.set_auto_conf(options)
+            node.stop()
+            node.slow_start()
+
+            auto_conf_path = f"{node.data_dir}/postgresql.auto.conf"
+            with open(auto_conf_path, "r") as f:
+                content = f.read()
+                self.assertIn(
+                    "archive_command = 'cp \\'%p\\' \"/mnt/server/archivedir/%f\"",
+                    content,
+                    "archive_command stored wrong"
+                )
+                self.assertIn(
+                    "restore_command = 'cp \"/mnt/server/archivedir/%f\" \\'%p\\''",
+                    content,
+                    "restore_command stored wrong"
+                )
+
 
 if __name__ == '__main__':
     if os.environ.get('ALT_CONFIG'):


### PR DESCRIPTION
This patch improves an PostgresNode::set_auto_conf method

New implementation does the following things:
- escaping '\n', '\r', '\t', '\b' and '\\' symbols
- translating bool-values into 'on|off'
- saving a presentation of values those were not changed

This patch closes a problem with storing a command line with quotes in postgres' configuration files.

A test is provided.

---
It is a temporary solution to exist problems. In the future we should work with configuration files a more cleverly:
- do not reorder declarations
- do not remove comments
