### PR TITLE
NodeApp::make_simple is refactored (tempfile.gettempdir)

### DIFF
--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1807,8 +1807,8 @@ class NodeApp:
             options['wal_keep_segments'] = '12'
 
         # Apply given parameters
-        for x in pg_options:
-            options[x] = pg_options[x]
+        for option_name, option_value in iteritems(pg_options):
+            options[option_name] = option_value
 
         # Define delayed propertyes
         if not ("unix_socket_directories" in options.keys()):

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1790,7 +1790,7 @@ class NodeApp:
             'log_disconnections': 'on',
             'restart_after_crash': 'off',
             'autovacuum': 'off',
-            # 'unix_socket_directories': '/tmp',
+            # unix_socket_directories will be defined later
         }
 
         # Allow replication in pg_hba.conf


### PR DESCRIPTION
- [BUG FIX] Windows does not have "/tmp" directory. Let's use tempfile.gettempdir() to detect temp directory correctly.
- Aggregation of standard and custom options to avoid two calls of node.set_auto_conf