### PR TITLE
Port numbers management is improved (#164)

### DIFF
--- a/testgres/operations/local_ops.py
+++ b/testgres/operations/local_ops.py
@@ -308,6 +308,17 @@ class LocalOperations(OsOperations):
                         buffers * max(2, int(num_lines / max(cur_lines, 1)))
                     )  # Adjust buffer size
 
+    def read_binary(self, filename, start_pos):
+        assert type(filename) == str  # noqa: E721
+        assert type(start_pos) == int  # noqa: E721
+        assert start_pos >= 0
+
+        with open(filename, 'rb') as file:  # open in a binary mode
+            file.seek(start_pos, os.SEEK_SET)
+            r = file.read()
+            assert type(r) == bytes  # noqa: E721
+            return r
+
     def isfile(self, remote_file):
         return os.path.isfile(remote_file)
 

--- a/testgres/operations/local_ops.py
+++ b/testgres/operations/local_ops.py
@@ -325,6 +325,11 @@ class LocalOperations(OsOperations):
     def isdir(self, dirname):
         return os.path.isdir(dirname)
 
+    def get_file_size(self, filename):
+        assert filename is not None
+        assert type(filename) == str  # noqa: E721
+        return os.path.getsize(filename)
+
     def remove_file(self, filename):
         return os.remove(filename)
 

--- a/testgres/operations/os_ops.py
+++ b/testgres/operations/os_ops.py
@@ -107,6 +107,9 @@ class OsOperations:
     def isfile(self, remote_file):
         raise NotImplementedError()
 
+    def get_file_size(self, filename):
+        raise NotImplementedError()
+
     # Processes control
     def kill(self, pid, signal):
         # Kill the process

--- a/testgres/operations/os_ops.py
+++ b/testgres/operations/os_ops.py
@@ -98,6 +98,12 @@ class OsOperations:
     def readlines(self, filename):
         raise NotImplementedError()
 
+    def read_binary(self, filename, start_pos):
+        assert type(filename) == str  # noqa: E721
+        assert type(start_pos) == int  # noqa: E721
+        assert start_pos >= 0
+        raise NotImplementedError()
+
     def isfile(self, remote_file):
         raise NotImplementedError()
 

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -340,6 +340,16 @@ class RemoteOperations(OsOperations):
 
         return lines
 
+    def read_binary(self, filename, start_pos):
+        assert type(filename) == str  # noqa: E721
+        assert type(start_pos) == int  # noqa: E721
+        assert start_pos >= 0
+
+        cmd = "tail -c +{} {}".format(start_pos + 1, __class__._escape_path(filename))
+        r = self.exec_command(cmd)
+        assert type(r) == bytes  # noqa: E721
+        return r
+
     def isfile(self, remote_file):
         stdout = self.exec_command("test -f {}; echo $?".format(remote_file))
         result = int(stdout.strip())
@@ -385,6 +395,15 @@ class RemoteOperations(OsOperations):
             password=password,
         )
         return conn
+
+    def _escape_path(path):
+        assert type(path) == str  # noqa: E721
+        assert path != ""  # Ok?
+
+        r = "'"
+        r += path
+        r += "'"
+        return r
 
 
 def normalize_error(error):

--- a/testgres/utils.py
+++ b/testgres/utils.py
@@ -34,7 +34,7 @@ class PgVer(Version):
             super().__init__(version)
 
 
-def reserve_port():
+def internal__reserve_port():
     """
     Generate a new port and add it to 'bound_ports'.
     """
@@ -45,12 +45,16 @@ def reserve_port():
     return port
 
 
-def release_port(port):
+def internal__release_port(port):
     """
     Free port provided by reserve_port().
     """
 
     bound_ports.discard(port)
+
+
+reserve_port = internal__reserve_port
+release_port = internal__release_port
 
 
 def execute_utility(args, logfile=None, verbose=False):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,4 +1,7 @@
+import os
+
 import pytest
+import re
 
 from testgres import ExecUtilException
 from testgres import LocalOperations
@@ -52,3 +55,45 @@ class TestLocalOperations:
         assert error == b'/bin/sh: 1: nonexistent_command: not found\n'
         assert exit_status == 127
         assert result == b''
+
+    def test_read_binary__spec(self):
+        """
+        Test LocalOperations::read_binary.
+        """
+        filename = __file__  # current file
+
+        with open(filename, 'rb') as file:  # open in a binary mode
+            response0 = file.read()
+
+        assert type(response0) == bytes  # noqa: E721
+
+        response1 = self.operations.read_binary(filename, 0)
+        assert type(response1) == bytes  # noqa: E721
+        assert response1 == response0
+
+        response2 = self.operations.read_binary(filename, 1)
+        assert type(response2) == bytes  # noqa: E721
+        assert len(response2) < len(response1)
+        assert len(response2) + 1 == len(response1)
+        assert response2 == response1[1:]
+
+        response3 = self.operations.read_binary(filename, len(response1))
+        assert type(response3) == bytes  # noqa: E721
+        assert len(response3) == 0
+
+        response4 = self.operations.read_binary(filename, len(response2))
+        assert type(response4) == bytes  # noqa: E721
+        assert len(response4) == 1
+        assert response4[0] == response1[len(response1) - 1]
+
+        response5 = self.operations.read_binary(filename, len(response1) + 1)
+        assert type(response5) == bytes  # noqa: E721
+        assert len(response5) == 0
+
+    def test_read_binary__spec__unk_file(self):
+        """
+        Test LocalOperations::read_binary with unknown file.
+        """
+
+        with pytest.raises(FileNotFoundError, match=re.escape("[Errno 2] No such file or directory: '/dummy'")):
+            self.operations.read_binary("/dummy", 0)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -97,3 +97,24 @@ class TestLocalOperations:
 
         with pytest.raises(FileNotFoundError, match=re.escape("[Errno 2] No such file or directory: '/dummy'")):
             self.operations.read_binary("/dummy", 0)
+
+    def test_get_file_size(self):
+        """
+        Test LocalOperations::get_file_size.
+        """
+        filename = __file__  # current file
+
+        sz0 = os.path.getsize(filename)
+        assert type(sz0) == int  # noqa: E721
+
+        sz1 = self.operations.get_file_size(filename)
+        assert type(sz1) == int  # noqa: E721
+        assert sz1 == sz0
+
+    def test_get_file_size__unk_file(self):
+        """
+        Test LocalOperations::get_file_size.
+        """
+
+        with pytest.raises(FileNotFoundError, match=re.escape("[Errno 2] No such file or directory: '/dummy'")):
+            self.operations.get_file_size("/dummy")

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -224,6 +224,27 @@ class TestRemoteOperations:
         with pytest.raises(ExecUtilException, match=re.escape("tail: cannot open '/dummy' for reading: No such file or directory")):
             self.operations.read_binary("/dummy", 0)
 
+    def test_get_file_size(self):
+        """
+        Test LocalOperations::get_file_size.
+        """
+        filename = __file__  # current file
+
+        sz0 = os.path.getsize(filename)
+        assert type(sz0) == int  # noqa: E721
+
+        sz1 = self.operations.get_file_size(filename)
+        assert type(sz1) == int  # noqa: E721
+        assert sz1 == sz0
+
+    def test_get_file_size__unk_file(self):
+        """
+        Test LocalOperations::get_file_size.
+        """
+
+        with pytest.raises(ExecUtilException, match=re.escape("du: cannot access '/dummy': No such file or directory")):
+            self.operations.get_file_size("/dummy")
+
     def test_touch(self):
         """
         Test touch for creating a new file or updating access and modification times of an existing file.

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1051,10 +1051,18 @@ class TestgresTests(unittest.TestCase):
     def test_the_same_port(self):
         with get_new_node() as node:
             node.init().start()
+            self.assertTrue(node._should_free_port)
+            self.assertEqual(type(node.port), int)
 
-            with get_new_node() as node2:
-                node2.port = node.port
-                node2.init().start()
+            with get_new_node(port=node.port) as node2:
+                self.assertEqual(type(node2.port), int)
+                self.assertEqual(node2.port, node.port)
+                self.assertFalse(node2._should_free_port)
+
+                with self.assertRaises(StartNodeException) as ctx:
+                    node2.init().start()
+
+                self.assertIn("Cannot start node", str(ctx.exception))
 
     def test_simple_with_bin_dir(self):
         with get_new_node() as node:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1064,6 +1064,123 @@ class TestgresTests(unittest.TestCase):
 
                 self.assertIn("Cannot start node", str(ctx.exception))
 
+    class tagPortManagerProxy:
+        sm_prev_testgres_reserve_port = None
+        sm_prev_testgres_release_port = None
+
+        sm_DummyPortNumber = None
+        sm_DummyPortMaxUsage = None
+
+        sm_DummyPortCurrentUsage = None
+        sm_DummyPortTotalUsage = None
+
+        def __init__(self, dummyPortNumber, dummyPortMaxUsage):
+            assert type(dummyPortNumber) == int  # noqa: E721
+            assert type(dummyPortMaxUsage) == int  # noqa: E721
+            assert dummyPortNumber >= 0
+            assert dummyPortMaxUsage >= 0
+
+            assert __class__.sm_prev_testgres_reserve_port is None
+            assert __class__.sm_prev_testgres_release_port is None
+            assert testgres.utils.reserve_port == testgres.utils.internal__reserve_port
+            assert testgres.utils.release_port == testgres.utils.internal__release_port
+
+            __class__.sm_prev_testgres_reserve_port = testgres.utils.reserve_port
+            __class__.sm_prev_testgres_release_port = testgres.utils.release_port
+
+            testgres.utils.reserve_port = __class__._proxy__reserve_port
+            testgres.utils.release_port = __class__._proxy__release_port
+
+            assert testgres.utils.reserve_port == __class__._proxy__reserve_port
+            assert testgres.utils.release_port == __class__._proxy__release_port
+
+            __class__.sm_DummyPortNumber = dummyPortNumber
+            __class__.sm_DummyPortMaxUsage = dummyPortMaxUsage
+
+            __class__.sm_DummyPortCurrentUsage = 0
+            __class__.sm_DummyPortTotalUsage = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, type, value, traceback):
+            assert __class__.sm_DummyPortCurrentUsage == 0
+
+            assert __class__.sm_prev_testgres_reserve_port is not None
+            assert __class__.sm_prev_testgres_release_port is not None
+
+            assert testgres.utils.reserve_port == __class__._proxy__reserve_port
+            assert testgres.utils.release_port == __class__._proxy__release_port
+
+            testgres.utils.reserve_port = __class__.sm_prev_testgres_reserve_port
+            testgres.utils.release_port = __class__.sm_prev_testgres_release_port
+
+            __class__.sm_prev_testgres_reserve_port = None
+            __class__.sm_prev_testgres_release_port = None
+
+        def _proxy__reserve_port():
+            assert type(__class__.sm_DummyPortMaxUsage) == int  # noqa: E721
+            assert type(__class__.sm_DummyPortTotalUsage) == int  # noqa: E721
+            assert type(__class__.sm_DummyPortCurrentUsage) == int  # noqa: E721
+            assert __class__.sm_DummyPortTotalUsage >= 0
+            assert __class__.sm_DummyPortCurrentUsage >= 0
+
+            assert __class__.sm_DummyPortTotalUsage <= __class__.sm_DummyPortMaxUsage
+            assert __class__.sm_DummyPortCurrentUsage <= __class__.sm_DummyPortTotalUsage
+
+            assert __class__.sm_prev_testgres_reserve_port is not None
+
+            if __class__.sm_DummyPortTotalUsage == __class__.sm_DummyPortMaxUsage:
+                return __class__.sm_prev_testgres_reserve_port()
+
+            __class__.sm_DummyPortTotalUsage += 1
+            __class__.sm_DummyPortCurrentUsage += 1
+            return __class__.sm_DummyPortNumber
+
+        def _proxy__release_port(dummyPortNumber):
+            assert type(dummyPortNumber) == int  # noqa: E721
+
+            assert type(__class__.sm_DummyPortMaxUsage) == int  # noqa: E721
+            assert type(__class__.sm_DummyPortTotalUsage) == int  # noqa: E721
+            assert type(__class__.sm_DummyPortCurrentUsage) == int  # noqa: E721
+            assert __class__.sm_DummyPortTotalUsage >= 0
+            assert __class__.sm_DummyPortCurrentUsage >= 0
+
+            assert __class__.sm_DummyPortTotalUsage <= __class__.sm_DummyPortMaxUsage
+            assert __class__.sm_DummyPortCurrentUsage <= __class__.sm_DummyPortTotalUsage
+
+            assert __class__.sm_prev_testgres_release_port is not None
+
+            if __class__.sm_DummyPortCurrentUsage > 0 and dummyPortNumber == __class__.sm_DummyPortNumber:
+                assert __class__.sm_DummyPortTotalUsage > 0
+                __class__.sm_DummyPortCurrentUsage -= 1
+                return
+
+            return __class__.sm_prev_testgres_release_port(dummyPortNumber)
+
+    def test_port_rereserve_during_node_start(self):
+        C_COUNT_OF_BAD_PORT_USAGE = 3
+
+        with get_new_node() as node1:
+            node1.init().start()
+            self.assertTrue(node1._should_free_port)
+            self.assertEqual(type(node1.port), int)  # noqa: E721
+            node1.safe_psql("SELECT 1;")
+
+            with __class__.tagPortManagerProxy(node1.port, C_COUNT_OF_BAD_PORT_USAGE):
+                assert __class__.tagPortManagerProxy.sm_DummyPortNumber == node1.port
+                with get_new_node() as node2:
+                    self.assertTrue(node2._should_free_port)
+                    self.assertEqual(node2.port, node1.port)
+
+                    node2.init().start()
+
+                    self.assertNotEqual(node2.port, node1.port)
+                    self.assertEqual(__class__.tagPortManagerProxy.sm_DummyPortCurrentUsage, 0)
+                    self.assertEqual(__class__.tagPortManagerProxy.sm_DummyPortTotalUsage, C_COUNT_OF_BAD_PORT_USAGE)
+
+                    node2.safe_psql("SELECT 1;")
+
     def test_simple_with_bin_dir(self):
         with get_new_node() as node:
             node.init().start()


### PR DESCRIPTION
This PR improves a managemenet of port numbers.

- We don't release a port number that was defined by client
- We only check log files to detect port number conflicts
- We use slightly smarter log file checking

A test is added.

This patch closes the issue #164.