### PR TITLE
Node.start is refactored [Victoria Shepard' ideas are used, #149]

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1219,7 +1219,7 @@ class TestgresTests(unittest.TestCase):
                     with self.assertRaises(StartNodeException) as ctx:
                         node2.init().start()
 
-                    self.assertIn("Cannot start node", str(ctx.exception))
+                    self.assertIn("Cannot start node after multiple attempts", str(ctx.exception))
 
                     self.assertEqual(node2.port, node1.port)
                     self.assertTrue(node2._should_free_port)


### PR DESCRIPTION
- Save an orignal text of 'does not exist' error
- When we reach maximum retry attempt of restarts
  - We log an error message
  - We raise exception "Cannot start node after multiple attempts"
- A new port number is not tranlating into string
- Reorganization

TestgresTests.test_port_conflict is updated.