### PR TITLE
Ssh command line in RemoteOperations::execute is corrected

### DIFF
--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1125,10 +1125,7 @@ class PostgresNode(object):
 
         # select query source
         if query:
-            if self.os_ops.remote:
-                psql_params.extend(("-c", '"{}"'.format(query)))
-            else:
-                psql_params.extend(("-c", query))
+            psql_params.extend(("-c", query))
         elif filename:
             psql_params.extend(("-f", filename))
         else:

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -80,7 +80,10 @@ class RemoteOperations(OsOperations):
         if isinstance(cmd, str):
             ssh_cmd = ['ssh', self.ssh_dest] + self.ssh_args + [cmd]
         elif isinstance(cmd, list):
-            ssh_cmd = ['ssh', self.ssh_dest] + self.ssh_args + cmd
+            ssh_cmd = ['ssh', self.ssh_dest] + self.ssh_args + [subprocess.list2cmdline(cmd)]
+        else:
+            raise ValueError("Invalid 'cmd' argument type - {0}".format(type(cmd).__name__))
+
         process = subprocess.Popen(ssh_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         assert not (process is None)
         if get_process:


### PR DESCRIPTION
We use subprocess.list2cmdline(cmd) to pack a user command line.

It allows PostgresNode::_psql to build PSQL command line without a "special case" for remote-host.

Also

RemoteOperations::execute raises exception if 'cmd' parameter has an unknown type.