### PR TITLE
OsOps::read_binary is updated (offset)

### DIFF
--- a/testgres/operations/local_ops.py
+++ b/testgres/operations/local_ops.py
@@ -331,13 +331,15 @@ class LocalOperations(OsOperations):
                         buffers * max(2, int(num_lines / max(cur_lines, 1)))
                     )  # Adjust buffer size
 
-    def read_binary(self, filename, start_pos):
+    def read_binary(self, filename, offset):
         assert type(filename) == str  # noqa: E721
-        assert type(start_pos) == int  # noqa: E721
-        assert start_pos >= 0
+        assert type(offset) == int  # noqa: E721
+
+        if offset < 0:
+            raise ValueError("Negative 'offset' is not supported.")
 
         with open(filename, 'rb') as file:  # open in a binary mode
-            file.seek(start_pos, os.SEEK_SET)
+            file.seek(offset, os.SEEK_SET)
             r = file.read()
             assert type(r) == bytes  # noqa: E721
             return r

--- a/testgres/operations/os_ops.py
+++ b/testgres/operations/os_ops.py
@@ -98,10 +98,10 @@ class OsOperations:
     def readlines(self, filename):
         raise NotImplementedError()
 
-    def read_binary(self, filename, start_pos):
+    def read_binary(self, filename, offset):
         assert type(filename) == str  # noqa: E721
-        assert type(start_pos) == int  # noqa: E721
-        assert start_pos >= 0
+        assert type(offset) == int  # noqa: E721
+        assert offset >= 0
         raise NotImplementedError()
 
     def isfile(self, remote_file):

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -370,12 +370,14 @@ class RemoteOperations(OsOperations):
 
         return lines
 
-    def read_binary(self, filename, start_pos):
+    def read_binary(self, filename, offset):
         assert type(filename) == str  # noqa: E721
-        assert type(start_pos) == int  # noqa: E721
-        assert start_pos >= 0
+        assert type(offset) == int  # noqa: E721
 
-        cmd = ["tail", "-c", "+{}".format(start_pos + 1), filename]
+        if offset < 0:
+            raise ValueError("Negative 'offset' is not supported.")
+
+        cmd = ["tail", "-c", "+{}".format(offset + 1), filename]
         r = self.exec_command(cmd)
         assert type(r) == bytes  # noqa: E721
         return r

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -162,6 +162,16 @@ class TestLocalOperations:
                 match=re.escape("[Errno 2] No such file or directory: '/dummy'")):
             self.operations.read_binary("/dummy", 0)
 
+    def test_read_binary__spec__negative_offset(self):
+        """
+        Test LocalOperations::read_binary with negative offset.
+        """
+
+        with pytest.raises(
+                ValueError,
+                match=re.escape("Negative 'offset' is not supported.")):
+            self.operations.read_binary(__file__, -1)
+
     def test_get_file_size(self):
         """
         Test LocalOperations::get_file_size.

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -288,6 +288,16 @@ class TestRemoteOperations:
         with pytest.raises(ExecUtilException, match=re.escape("tail: cannot open '/dummy' for reading: No such file or directory")):
             self.operations.read_binary("/dummy", 0)
 
+    def test_read_binary__spec__negative_offset(self):
+        """
+        Test RemoteOperations::read_binary with negative offset.
+        """
+
+        with pytest.raises(
+                ValueError,
+                match=re.escape("Negative 'offset' is not supported.")):
+            self.operations.read_binary(__file__, -1)
+
     def test_get_file_size(self):
         """
         Test RemoteOperations::get_file_size.


### PR DESCRIPTION
- the parameter 'start_pos' is renamed with 'offset'
- we raise a runtime-error when 'offset' is negative

Tests are added.