### PR TITLE
PostgresNode::start is refactored

### DIFF
--- a/testgres/node.py
+++ b/testgres/node.py
@@ -848,7 +848,7 @@ class PostgresNode(object):
                     cur_port = self.port
                     new_port = utils.reserve_port()  # can raise
                     try:
-                        options = {'port': str(new_port)}
+                        options = {'port': new_port}
                         self.set_auto_conf(options)
                     except:  # noqa: E722
                         utils.release_port(new_port)


### PR DESCRIPTION
We do not translate a new node port into string when we pack it in a new option dictionary.