### PR TITLE
PortManager::find_free_port is updated

### DIFF
--- a/testgres/helpers/port_manager.py
+++ b/testgres/helpers/port_manager.py
@@ -26,8 +26,11 @@ class PortManager:
         if ports is None:
             ports = set(range(1024, 65535))
 
+        assert type(ports) == set
+
         if exclude_ports is not None:
-            ports.difference_update(set(exclude_ports))
+            assert isinstance(exclude_ports, Iterable)
+            ports.difference_update(exclude_ports)
 
         sampled_ports = random.sample(tuple(ports), min(len(ports), 100))
 

--- a/testgres/helpers/port_manager.py
+++ b/testgres/helpers/port_manager.py
@@ -26,7 +26,7 @@ class PortManager:
         if ports is None:
             ports = set(range(1024, 65535))
 
-        assert type(ports) == set
+        assert type(ports) == set  # noqa: E721
 
         if exclude_ports is not None:
             assert isinstance(exclude_ports, Iterable)

--- a/testgres/helpers/port_manager.py
+++ b/testgres/helpers/port_manager.py
@@ -26,10 +26,8 @@ class PortManager:
         if ports is None:
             ports = set(range(1024, 65535))
 
-        if exclude_ports is None:
-            exclude_ports = set()
-
-        ports.difference_update(set(exclude_ports))
+        if exclude_ports is not None:
+            ports.difference_update(set(exclude_ports))
 
         sampled_ports = random.sample(tuple(ports), min(len(ports), 100))
 


### PR DESCRIPTION
- We will use exclude_ports only when it is not none (creation of empty exclude_ports is removed)
- Asserts are added
- Do not convert exclude_ports into "set"