### PR TITLE
OsOperations::cwd() is corrected

### DIFF
--- a/testgres/operations/local_ops.py
+++ b/testgres/operations/local_ops.py
@@ -152,6 +152,9 @@ class LocalOperations(OsOperations):
     def environ(self, var_name):
         return os.environ.get(var_name)
 
+    def cwd(self):
+        return os.getcwd()
+
     def find_executable(self, executable):
         return find_executable(executable)
 

--- a/testgres/operations/os_ops.py
+++ b/testgres/operations/os_ops.py
@@ -1,6 +1,5 @@
 import getpass
 import locale
-import sys
 
 try:
     import psycopg2 as pglib  # noqa: F401
@@ -39,11 +38,7 @@ class OsOperations:
         raise NotImplementedError()
 
     def cwd(self):
-        if sys.platform == 'linux':
-            cmd = 'pwd'
-        elif sys.platform == 'win32':
-            cmd = 'cd'
-        return self.exec_command(cmd).decode().rstrip()
+        raise NotImplementedError()
 
     def find_executable(self, executable):
         raise NotImplementedError()

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -139,7 +139,6 @@ class RemoteOperations(OsOperations):
         return self.exec_command(cmd, encoding=get_default_encoding()).strip()
 
     def cwd(self):
-        assert platform.system().lower() == "linux"
         cmd = 'pwd'
         return self.exec_command(cmd, encoding=get_default_encoding()).rstrip()
 

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -138,6 +138,11 @@ class RemoteOperations(OsOperations):
         cmd = "echo ${}".format(var_name)
         return self.exec_command(cmd, encoding=get_default_encoding()).strip()
 
+    def cwd(self):
+        assert platform.system().lower() == "linux"
+        cmd = 'pwd'
+        return self.exec_command(cmd, encoding=get_default_encoding()).rstrip()
+
     def find_executable(self, executable):
         search_paths = self.environ("PATH")
         if not search_paths:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -256,3 +256,20 @@ class TestLocalOperations:
         response = self.operations.isdir(name)
 
         assert response is False
+
+    def test_cwd(self):
+        """
+        Test cwd.
+        """
+        v = self.operations.cwd()
+
+        assert v is not None
+        assert type(v) == str  # noqa: E721
+
+        expectedValue = os.getcwd()
+        assert expectedValue is not None
+        assert type(expectedValue) == str  # noqa: E721
+        assert expectedValue != ""  # research
+
+        # Comp result
+        assert v == expectedValue

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -392,3 +392,13 @@ class TestRemoteOperations:
         response = self.operations.isdir(name)
 
         assert response is False
+
+    def test_cwd(self):
+        """
+        Test cwd.
+        """
+        v = self.operations.cwd()
+
+        assert v is not None
+        assert type(v) == str  # noqa: E721
+        assert v != ""


### PR DESCRIPTION
This patch fixes the following problems:
 - os_ops.cwd() does not work on Windows
 - os_ops.cwd() always returns LOCAL path