### PR TITLE
RemoteOperations::exec_command explicitly transfers LANG, LANGUAGE and LC_* envvars to the server side

### DIFF
--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -87,7 +87,12 @@ class RemoteOperations(OsOperations):
 
         assert type(cmd_s) == str  # noqa: E721
 
-        ssh_cmd = ['ssh', self.ssh_dest] + self.ssh_args + [cmd_s]
+        cmd_items = __class__._make_exec_env_list()
+        cmd_items.append(cmd_s)
+
+        env_cmd_s = ';'.join(cmd_items)
+
+        ssh_cmd = ['ssh', self.ssh_dest] + self.ssh_args + [env_cmd_s]
 
         process = subprocess.Popen(ssh_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         assert not (process is None)
@@ -509,6 +514,42 @@ class RemoteOperations(OsOperations):
             password=password,
         )
         return conn
+
+    def _make_exec_env_list() -> list[str]:
+        result = list[str]()
+        for envvar in os.environ.items():
+            if not __class__._does_put_envvar_into_exec_cmd(envvar[0]):
+                continue
+            qvalue = __class__._quote_envvar(envvar[1])
+            assert type(qvalue) == str   # noqa: E721
+            result.append(envvar[0] + "=" + qvalue)
+            continue
+
+        return result
+
+    sm_envs_for_exec_cmd = ["LANG", "LANGUAGE"]
+
+    def _does_put_envvar_into_exec_cmd(name: str) -> bool:
+        assert type(name) == str  # noqa: E721
+        name = name.upper()
+        if name.startswith("LC_"):
+            return True
+        if name in __class__.sm_envs_for_exec_cmd:
+            return True
+        return False
+
+    def _quote_envvar(value) -> str:
+        assert type(value) == str  # noqa: E721
+        result = "\""
+        for ch in value:
+            if ch == "\"":
+                result += "\\\""
+            elif ch == "\\":
+                result += "\\\\"
+            else:
+                result += ch
+        result += "\""
+        return result
 
 
 def normalize_error(error):

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -78,13 +78,16 @@ class RemoteOperations(OsOperations):
 
         assert input_prepared is None or (type(input_prepared) == bytes)  # noqa: E721
 
-        ssh_cmd = []
-        if isinstance(cmd, str):
-            ssh_cmd = ['ssh', self.ssh_dest] + self.ssh_args + [cmd]
-        elif isinstance(cmd, list):
-            ssh_cmd = ['ssh', self.ssh_dest] + self.ssh_args + [subprocess.list2cmdline(cmd)]
+        if type(cmd) == str:  # noqa: E721
+            cmd_s = cmd
+        elif type(cmd) == list:  # noqa: E721
+            cmd_s = subprocess.list2cmdline(cmd)
         else:
             raise ValueError("Invalid 'cmd' argument type - {0}".format(type(cmd).__name__))
+
+        assert type(cmd_s) == str  # noqa: E721
+
+        ssh_cmd = ['ssh', self.ssh_dest] + self.ssh_args + [cmd_s]
 
         process = subprocess.Popen(ssh_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         assert not (process is None)

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -515,6 +515,7 @@ class RemoteOperations(OsOperations):
         )
         return conn
 
+    @staticmethod
     def _make_exec_env_list() -> list[str]:
         result = list[str]()
         for envvar in os.environ.items():
@@ -529,6 +530,7 @@ class RemoteOperations(OsOperations):
 
     sm_envs_for_exec_cmd = ["LANG", "LANGUAGE"]
 
+    @staticmethod
     def _does_put_envvar_into_exec_cmd(name: str) -> bool:
         assert type(name) == str  # noqa: E721
         name = name.upper()
@@ -538,6 +540,7 @@ class RemoteOperations(OsOperations):
             return True
         return False
 
+    @staticmethod
     def _quote_envvar(value) -> str:
         assert type(value) == str  # noqa: E721
         result = "\""

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -541,7 +541,7 @@ class RemoteOperations(OsOperations):
         return False
 
     @staticmethod
-    def _quote_envvar(value) -> str:
+    def _quote_envvar(value: str) -> str:
         assert type(value) == str  # noqa: E721
         result = "\""
         for ch in value:

--- a/tests/test_simple_remote.py
+++ b/tests/test_simple_remote.py
@@ -119,6 +119,56 @@ class TestgresRemoteTests(unittest.TestCase):
             # there should be no trust entries at all
             self.assertFalse(any('trust' in s for s in lines))
 
+    def test_init__LANG_С(self):
+        # PBCKP-1744
+        prev_LANG = os.environ.get("LANG")
+
+        try:
+            os.environ["LANG"] = "C"
+
+            with get_remote_node(conn_params=conn_params) as node:
+                node.init().start()
+        finally:
+            __class__.helper__restore_envvar("LANG", prev_LANG)
+
+    def test_init__unk_LANG_and_LC_CTYPE(self):
+        # PBCKP-1744
+        prev_LANG = os.environ.get("LANG")
+        prev_LANGUAGE = os.environ.get("LANGUAGE")
+        prev_LC_CTYPE = os.environ.get("LC_CTYPE")
+        prev_LC_COLLATE = os.environ.get("LC_COLLATE")
+
+        try:
+            os.environ["LANG"] = "UNKNOWN_LANG"
+            os.environ.pop("LANGUAGE", None)
+            os.environ["LC_CTYPE"] = "UNKNOWN_CTYPE"
+            os.environ.pop("LC_COLLATE", None)
+
+            assert os.environ.get("LANG") == "UNKNOWN_LANG"
+            assert not ("LANGUAGE" in os.environ.keys())
+            assert os.environ.get("LC_CTYPE") == "UNKNOWN_CTYPE"
+            assert not ("LC_COLLATE" in os.environ.keys())
+
+            while True:
+                try:
+                    with get_remote_node(conn_params=conn_params):
+                        pass
+                except testgres.exceptions.ExecUtilException as e:
+                    # warning: setlocale: LC_CTYPE: cannot change locale (UNKNOWN_CTYPE): No such file or directory
+                    # postgres (PostgreSQL) 14.12
+                    errMsg = str(e)
+                    assert "LC_CTYPE" in errMsg
+                    assert "UNKNOWN_CTYPE" in errMsg
+                    assert "warning: setlocale: LC_CTYPE: cannot change locale (UNKNOWN_CTYPE): No such file or directory" in errMsg
+                    assert "postgres" in errMsg
+                    break
+                raise Exception("We expected an error!")
+        finally:
+            __class__.helper__restore_envvar("LANG", prev_LANG)
+            __class__.helper__restore_envvar("LANGUAGE", prev_LANGUAGE)
+            __class__.helper__restore_envvar("LC_CTYPE", prev_LC_CTYPE)
+            __class__.helper__restore_envvar("LC_COLLATE", prev_LC_COLLATE)
+
     def test_double_init(self):
         with get_remote_node(conn_params=conn_params).init() as node:
             # can't initialize node more than once
@@ -993,6 +1043,12 @@ class TestgresRemoteTests(unittest.TestCase):
             process.wait()
             # try to handle children list -- missing processes will have ptype "ProcessType.Unknown"
             [ProcessProxy(p) for p in children]
+
+    def helper__restore_envvar(name, prev_value):
+        if prev_value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = prev_value
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It should help resolve a problem with replacing the LANG variable by ssh-server.

History.

On our internal tests we got a problem on the Debian 11 and PostgresPro STD-13.

One test returned the error of initdb:

initdb: error: collations with different collate and ctype values ("en_US.UTF-8" and "C.UTF-8" accordingly) are not supported by ICU

- A test runner sets variable LANG="C"
- Python sets variable LC_CTYPE="C.UTF-8"
- A test calls initdb through command "ssh test@localhost inidb -D ...."
- SSH-server replaces LANG with value "en_US.UTF-8" (from etc/default/locale)
- initdb calculates a collate through this value of LANG variable and gets "en_US.UTF-8"

So we have that:
- ctype is "C.UTF-8"
- collate is "en_US.UTF-8"

ICU on the Debuan-11 (uconv v2.1  ICU 67.1) does not support this combination and initdb returns the error.

This patch generates a new command line for ssh:

```bash
ssh test@localhost "LANG=\"...\";LC_xxx=\"...\";<command>"
```
It resolves this problem with initdb and should help resolve other problems with execution of commands through SSH.