### PR TITLE
Fix for "ERROR: Unexpected indentation. [docutils]"

### DIFF
--- a/testgres/api.py
+++ b/testgres/api.py
@@ -47,8 +47,6 @@ def get_remote_node(name=None, conn_params=None):
     Simply a wrapper around :class:`.PostgresNode` constructor for remote node.
     See :meth:`.PostgresNode.__init__` for details.
     For remote connection you can add the next parameter:
-    conn_params = ConnectionParams(host='127.0.0.1',
-                                   ssh_key=None,
-                                   username=default_username())
+    conn_params = ConnectionParams(host='127.0.0.1', ssh_key=None, username=default_username())
     """
     return get_new_node(name=name, conn_params=conn_params)


### PR DESCRIPTION
This commit should fix an unstable error in CI:

/pg/testgres/testgres/api.py:docstring of testgres.api.get_remote_node:5: ERROR: Unexpected indentation. [docutils]