### PR TITLE
TestgresRemoteTests::helper__restore_envvar is marked with @staticmethod

### DIFF
--- a/tests/test_simple_remote.py
+++ b/tests/test_simple_remote.py
@@ -1067,6 +1067,7 @@ class TestgresRemoteTests(unittest.TestCase):
             # try to handle children list -- missing processes will have ptype "ProcessType.Unknown"
             [ProcessProxy(p) for p in children]
 
+    @staticmethod
     def helper__restore_envvar(name, prev_value):
         if prev_value is None:
             os.environ.pop(name, None)


### PR DESCRIPTION
Refactoring.