### PR TITLE
[run_tests.sh] A right way for obtaining of  BINDIR and PG_CONFIG is used

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -43,13 +43,13 @@ time coverage run -a -m pytest -l -v -n 4 -k "TestgresTests"
 
 # run tests (PG_BIN)
 time \
-	PG_BIN=$(dirname $(which pg_config)) \
+	PG_BIN=$(pg_config --bindir) \
 	coverage run -a -m pytest -l -v -n 4 -k "TestgresTests"
 
 
 # run tests (PG_CONFIG)
 time \
-	PG_CONFIG=$(which pg_config) \
+	PG_CONFIG=$(pg_config --bindir)/pg_config \
 	coverage run -a -m pytest -l -v -n 4 -k "TestgresTests"
 
 


### PR DESCRIPTION
A problem was detected in container with Ubuntu 24.04.

tests works with "/usr/bin/pg_config" but real pg_config is "/usr/lib/postgresql/17/bin/pg_config".

To resovle this problem we will call "pg_config --bindir" and use it result for BINDIR and PG_CONFIG.