### PR TITLE
Total refactoring of os_ops::execute_command

### DIFF
--- a/testgres/operations/local_ops.py
+++ b/testgres/operations/local_ops.py
@@ -135,6 +135,7 @@ class LocalOperations(OsOperations):
             RaiseError.UtilityExitedWithNonZeroCode(
                 cmd=cmd,
                 exit_code=process.returncode,
+                msg_arg=error or output,
                 error=error,
                 out=output)
 

--- a/testgres/operations/raise_error.py
+++ b/testgres/operations/raise_error.py
@@ -1,13 +1,22 @@
 from ..exceptions import ExecUtilException
+from .helpers import Helpers
 
 
 class RaiseError:
     @staticmethod
-    def UtilityExitedWithNonZeroCode(cmd, exit_code, error, out):
+    def UtilityExitedWithNonZeroCode(cmd, exit_code, msg_arg, error, out):
         assert type(exit_code) == int  # noqa: E721
 
+        msg_arg_s = __class__._TranslateDataIntoString(msg_arg)
+        assert type(msg_arg_s) == str  # noqa: E721
+
+        msg_arg_s = msg_arg_s.strip()
+        if msg_arg_s == "":
+            msg_arg_s = "#no_error_message"
+
+        message = "Utility exited with non-zero code (" + str(exit_code) + "). Error: `" + msg_arg_s + "`"
         raise ExecUtilException(
-            message="Utility exited with non-zero code.",
+            message=message,
             command=cmd,
             exit_code=exit_code,
             out=out,
@@ -25,3 +34,24 @@ class RaiseError:
             exit_code=exit_code,
             out=out,
             error=error)
+
+    @staticmethod
+    def _TranslateDataIntoString(data):
+        if data is None:
+            return ""
+
+        if type(data) == bytes:  # noqa: E721
+            return __class__._TranslateDataIntoString__FromBinary(data)
+
+        return str(data)
+
+    @staticmethod
+    def _TranslateDataIntoString__FromBinary(data):
+        assert type(data) == bytes  # noqa: E721
+
+        try:
+            return data.decode(Helpers.GetDefaultEncoding())
+        except UnicodeDecodeError:
+            pass
+
+        return "#cannot_decode_text"

--- a/testgres/operations/raise_error.py
+++ b/testgres/operations/raise_error.py
@@ -1,50 +1,27 @@
 from ..exceptions import ExecUtilException
-from .helpers import Helpers
 
 
 class RaiseError:
     @staticmethod
-    def UtilityExitedWithNonZeroCode(cmd, exit_code, msg_arg, error, out):
+    def UtilityExitedWithNonZeroCode(cmd, exit_code, error, out):
         assert type(exit_code) == int  # noqa: E721
 
-        msg_arg_s = __class__._TranslateDataIntoString(msg_arg).strip()
-        assert type(msg_arg_s) == str  # noqa: E721
-
-        if msg_arg_s == "":
-            msg_arg_s = "#no_error_message"
-
-        message = "Utility exited with non-zero code. Error: `" + msg_arg_s + "`"
         raise ExecUtilException(
-            message=message,
+            message="Utility exited with non-zero code.",
             command=cmd,
             exit_code=exit_code,
             out=out,
             error=error)
 
     @staticmethod
-    def _TranslateDataIntoString(data):
-        if type(data) == bytes:  # noqa: E721
-            return __class__._TranslateDataIntoString__FromBinary(data)
+    def CommandExecutionError(cmd, exit_code, message, error, out):
+        assert type(exit_code) == int  # noqa: E721
+        assert type(message) == str  # noqa: E721
+        assert message != ""
 
-        return str(data)
-
-    @staticmethod
-    def _TranslateDataIntoString__FromBinary(data):
-        assert type(data) == bytes  # noqa: E721
-
-        try:
-            return data.decode(Helpers.GetDefaultEncoding())
-        except UnicodeDecodeError:
-            pass
-
-        return "#cannot_decode_text"
-
-    @staticmethod
-    def _BinaryIsASCII(data):
-        assert type(data) == bytes  # noqa: E721
-
-        for b in data:
-            if not (b >= 0 and b <= 127):
-                return False
-
-        return True
+        raise ExecUtilException(
+            message=message,
+            command=cmd,
+            exit_code=exit_code,
+            out=out,
+            error=error)

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -126,6 +126,7 @@ class RemoteOperations(OsOperations):
             RaiseError.UtilityExitedWithNonZeroCode(
                 cmd=cmd,
                 exit_code=process.returncode,
+                msg_arg=error,
                 error=error,
                 out=output)
 
@@ -180,7 +181,7 @@ class RemoteOperations(OsOperations):
             exit_status,
             file)
 
-        RaiseError.UtilityExitedWithNonZeroCode(
+        RaiseError.CommandExecutionError(
             cmd=command,
             exit_code=exit_status,
             msg_arg=errMsg,

--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -100,41 +100,39 @@ class RemoteOperations(OsOperations):
             return process
 
         try:
-            result, error = process.communicate(input=input_prepared, timeout=timeout)
+            output, error = process.communicate(input=input_prepared, timeout=timeout)
         except subprocess.TimeoutExpired:
             process.kill()
             raise ExecUtilException("Command timed out after {} seconds.".format(timeout))
 
-        exit_status = process.returncode
-
-        assert type(result) == bytes  # noqa: E721
+        assert type(output) == bytes  # noqa: E721
         assert type(error) == bytes  # noqa: E721
 
-        if not error:
-            error_found = False
-        else:
-            error_found = exit_status != 0 or any(
-                marker in error for marker in [b'error', b'Permission denied', b'fatal', b'No such file or directory']
-            )
-
-        assert type(error_found) == bool  # noqa: E721
-
         if encoding:
-            result = result.decode(encoding)
+            output = output.decode(encoding)
             error = error.decode(encoding)
 
-        if not ignore_errors and error_found and not expect_error:
+        if expect_error:
+            if process.returncode == 0:
+                raise InvalidOperationException("We expected an execution error.")
+        elif ignore_errors:
+            pass
+        elif process.returncode == 0:
+            pass
+        else:
+            assert not expect_error
+            assert not ignore_errors
+            assert process.returncode != 0
             RaiseError.UtilityExitedWithNonZeroCode(
                 cmd=cmd,
-                exit_code=exit_status,
-                msg_arg=error,
+                exit_code=process.returncode,
                 error=error,
-                out=result)
+                out=output)
 
         if verbose:
-            return exit_status, result, error
-        else:
-            return result
+            return process.returncode, output, error
+
+        return output
 
     # Environment setup
     def environ(self, var_name: str) -> str:
@@ -165,8 +163,30 @@ class RemoteOperations(OsOperations):
 
     def is_executable(self, file):
         # Check if the file is executable
-        is_exec = self.exec_command("test -x {} && echo OK".format(file))
-        return is_exec == b"OK\n"
+        command = ["test", "-x", file]
+
+        exit_status, output, error = self.exec_command(cmd=command, encoding=get_default_encoding(), ignore_errors=True, verbose=True)
+
+        assert type(output) == str  # noqa: E721
+        assert type(error) == str  # noqa: E721
+
+        if exit_status == 0:
+            return True
+
+        if exit_status == 1:
+            return False
+
+        errMsg = "Test operation returns an unknown result code: {0}. File name is [{1}].".format(
+            exit_status,
+            file)
+
+        RaiseError.UtilityExitedWithNonZeroCode(
+            cmd=command,
+            exit_code=exit_status,
+            msg_arg=errMsg,
+            error=error,
+            out=output
+        )
 
     def set_env(self, var_name: str, var_val: str):
         """
@@ -251,15 +271,21 @@ class RemoteOperations(OsOperations):
         else:
             command = ["mktemp", "-d"]
 
-        exit_status, result, error = self.exec_command(command, verbose=True, encoding=get_default_encoding(), ignore_errors=True)
+        exec_exitcode, exec_output, exec_error = self.exec_command(command, verbose=True, encoding=get_default_encoding(), ignore_errors=True)
 
-        assert type(result) == str  # noqa: E721
-        assert type(error) == str  # noqa: E721
+        assert type(exec_exitcode) == int  # noqa: E721
+        assert type(exec_output) == str  # noqa: E721
+        assert type(exec_error) == str  # noqa: E721
 
-        if exit_status != 0:
-            raise ExecUtilException("Could not create temporary directory. Error code: {0}. Error message: {1}".format(exit_status, error))
+        if exec_exitcode != 0:
+            RaiseError.CommandExecutionError(
+                cmd=command,
+                exit_code=exec_exitcode,
+                message="Could not create temporary directory.",
+                error=exec_error,
+                out=exec_output)
 
-        temp_dir = result.strip()
+        temp_dir = exec_output.strip()
         return temp_dir
 
     def mkstemp(self, prefix=None):
@@ -273,15 +299,21 @@ class RemoteOperations(OsOperations):
         else:
             command = ["mktemp"]
 
-        exit_status, result, error = self.exec_command(command, verbose=True, encoding=get_default_encoding(), ignore_errors=True)
+        exec_exitcode, exec_output, exec_error = self.exec_command(command, verbose=True, encoding=get_default_encoding(), ignore_errors=True)
 
-        assert type(result) == str  # noqa: E721
-        assert type(error) == str  # noqa: E721
+        assert type(exec_exitcode) == int  # noqa: E721
+        assert type(exec_output) == str  # noqa: E721
+        assert type(exec_error) == str  # noqa: E721
 
-        if exit_status != 0:
-            raise ExecUtilException("Could not create temporary file. Error code: {0}. Error message: {1}".format(exit_status, error))
+        if exec_exitcode != 0:
+            RaiseError.CommandExecutionError(
+                cmd=command,
+                exit_code=exec_exitcode,
+                message="Could not create temporary file.",
+                error=exec_error,
+                out=exec_output)
 
-        temp_file = result.strip()
+        temp_file = exec_output.strip()
         return temp_file
 
     def copytree(self, src, dst):

--- a/testgres/utils.py
+++ b/testgres/utils.py
@@ -18,6 +18,7 @@ from .exceptions import ExecUtilException
 from .config import testgres_config as tconf
 from .operations.os_ops import OsOperations
 from .operations.remote_ops import RemoteOperations
+from .operations.helpers import Helpers as OsHelpers
 
 # rows returned by PG_CONFIG
 _pg_config_data = {}
@@ -79,13 +80,13 @@ def execute_utility2(os_ops: OsOperations, args, logfile=None, verbose=False, ig
     assert type(verbose) == bool  # noqa: E721
     assert type(ignore_errors) == bool  # noqa: E721
 
-    exit_status, out, error = os_ops.exec_command(args, verbose=True, ignore_errors=ignore_errors)
-    # decode result
+    exit_status, out, error = os_ops.exec_command(
+        args,
+        verbose=True,
+        ignore_errors=ignore_errors,
+        encoding=OsHelpers.GetDefaultEncoding())
+
     out = '' if not out else out
-    if isinstance(out, bytes):
-        out = out.decode('utf-8')
-    if isinstance(error, bytes):
-        error = error.decode('utf-8')
 
     # write new log entry if possible
     if logfile:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -40,7 +40,7 @@ class TestLocalOperations:
             try:
                 self.operations.exec_command(cmd, wait_exit=True, shell=True)
             except ExecUtilException as e:
-                assert e.message == "Utility exited with non-zero code."
+                assert e.message == "Utility exited with non-zero code (127). Error: `/bin/sh: 1: nonexistent_command: not found`"
                 assert type(e.error) == bytes  # noqa: E721
                 assert e.error.strip() == b"/bin/sh: 1: nonexistent_command: not found"
                 break

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -40,10 +40,11 @@ class TestLocalOperations:
             try:
                 self.operations.exec_command(cmd, wait_exit=True, shell=True)
             except ExecUtilException as e:
-                error = e.message
+                assert e.message == "Utility exited with non-zero code."
+                assert type(e.error) == bytes  # noqa: E721
+                assert e.error.strip() == b"/bin/sh: 1: nonexistent_command: not found"
                 break
             raise Exception("We wait an exception!")
-        assert error == "Utility exited with non-zero code. Error: `/bin/sh: 1: nonexistent_command: not found`"
 
     def test_exec_command_failure__expect_error(self):
         """

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -38,10 +38,11 @@ class TestRemoteOperations:
             try:
                 self.operations.exec_command(cmd, verbose=True, wait_exit=True)
             except ExecUtilException as e:
-                error = e.message
+                assert e.message == "Utility exited with non-zero code."
+                assert type(e.error) == bytes  # noqa: E721
+                assert e.error.strip() == b"bash: line 1: nonexistent_command: command not found"
                 break
             raise Exception("We wait an exception!")
-        assert error == 'Utility exited with non-zero code. Error: `bash: line 1: nonexistent_command: command not found`'
 
     def test_exec_command_failure__expect_error(self):
         """
@@ -108,10 +109,11 @@ class TestRemoteOperations:
             try:
                 self.operations.rmdirs(path, verbose=True)
             except ExecUtilException as e:
-                error = e.message
+                assert e.message == "Utility exited with non-zero code."
+                assert type(e.error) == bytes  # noqa: E721
+                assert e.error.strip() == b"rm: cannot remove '/root/test_dir': Permission denied"
                 break
             raise Exception("We wait an exception!")
-        assert error == "Utility exited with non-zero code. Error: `rm: cannot remove '/root/test_dir': Permission denied`"
 
     def test_listdir(self):
         """

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -38,7 +38,7 @@ class TestRemoteOperations:
             try:
                 self.operations.exec_command(cmd, verbose=True, wait_exit=True)
             except ExecUtilException as e:
-                assert e.message == "Utility exited with non-zero code."
+                assert e.message == "Utility exited with non-zero code (127). Error: `bash: line 1: nonexistent_command: command not found`"
                 assert type(e.error) == bytes  # noqa: E721
                 assert e.error.strip() == b"bash: line 1: nonexistent_command: command not found"
                 break
@@ -109,7 +109,7 @@ class TestRemoteOperations:
             try:
                 self.operations.rmdirs(path, verbose=True)
             except ExecUtilException as e:
-                assert e.message == "Utility exited with non-zero code."
+                assert e.message == "Utility exited with non-zero code (1). Error: `rm: cannot remove '/root/test_dir': Permission denied`"
                 assert type(e.error) == bytes  # noqa: E721
                 assert e.error.strip() == b"rm: cannot remove '/root/test_dir': Permission denied"
                 break


### PR DESCRIPTION
Main
 - We check only an exit code to detect an error.
 - If someone utility returns a result through an exit code, a caller side should set ignore_errors=true and process this case itself.
 - If expect_error is true and no errors occurred, we raise an InvalidOperationException.