### PR TITLE
os_ops::rmdirs (local, remote) was refactored

### DIFF
--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -117,6 +117,58 @@ class TestRemoteOperations:
         assert self.operations.rmdirs(path, ignore_errors=False) is True
         assert not os.path.exists(path)
 
+    def test_rmdirs__01_with_subfolder(self):
+        # folder with subfolder
+        path = self.operations.mkdtemp()
+        assert os.path.exists(path)
+
+        dir1 = os.path.join(path, "dir1")
+        assert not os.path.exists(dir1)
+
+        self.operations.makedirs(dir1)
+        assert os.path.exists(dir1)
+
+        assert self.operations.rmdirs(path, ignore_errors=False) is True
+        assert not os.path.exists(path)
+        assert not os.path.exists(dir1)
+
+    def test_rmdirs__02_with_file(self):
+        # folder with file
+        path = self.operations.mkdtemp()
+        assert os.path.exists(path)
+
+        file1 = os.path.join(path, "file1.txt")
+        assert not os.path.exists(file1)
+
+        self.operations.touch(file1)
+        assert os.path.exists(file1)
+
+        assert self.operations.rmdirs(path, ignore_errors=False) is True
+        assert not os.path.exists(path)
+        assert not os.path.exists(file1)
+
+    def test_rmdirs__03_with_subfolder_and_file(self):
+        # folder with subfolder and file
+        path = self.operations.mkdtemp()
+        assert os.path.exists(path)
+
+        dir1 = os.path.join(path, "dir1")
+        assert not os.path.exists(dir1)
+
+        self.operations.makedirs(dir1)
+        assert os.path.exists(dir1)
+
+        file1 = os.path.join(dir1, "file1.txt")
+        assert not os.path.exists(file1)
+
+        self.operations.touch(file1)
+        assert os.path.exists(file1)
+
+        assert self.operations.rmdirs(path, ignore_errors=False) is True
+        assert not os.path.exists(path)
+        assert not os.path.exists(dir1)
+        assert not os.path.exists(file1)
+
     def test_rmdirs__try_to_delete_nonexist_path(self):
         path = "/root/test_dir"
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -428,16 +428,61 @@ class TestgresTests:
                 node.backup(xlog_method='wrong')
 
     def test_pg_ctl_wait_option(self):
-        with get_new_node() as node:
-            node.init().start(wait=False)
-            while True:
-                try:
-                    node.stop(wait=False)
-                    break
-                except ExecUtilException:
-                    # it's ok to get this exception here since node
-                    # could be not started yet
-                    pass
+        C_MAX_ATTEMPTS = 50
+
+        node = get_new_node()
+        assert node.status() == testgres.NodeStatus.Uninitialized
+        node.init()
+        assert node.status() == testgres.NodeStatus.Stopped
+        node.start(wait=False)
+        nAttempt = 0
+        while True:
+            if nAttempt == C_MAX_ATTEMPTS:
+                raise Exception("Could not stop node.")
+
+            nAttempt += 1
+
+            if nAttempt > 1:
+                logging.info("Wait 1 second.")
+                time.sleep(1)
+                logging.info("")
+
+            logging.info("Try to stop node. Attempt #{0}.".format(nAttempt))
+
+            try:
+                node.stop(wait=False)
+                break
+            except ExecUtilException as e:
+                # it's ok to get this exception here since node
+                # could be not started yet
+                logging.info("Node is not stopped. Exception ({0}): {1}".format(type(e).__name__, e))
+            continue
+
+        logging.info("OK. Stop command was executed. Let's wait while our node will stop really.")
+        nAttempt = 0
+        while True:
+            if nAttempt == C_MAX_ATTEMPTS:
+                raise Exception("Could not stop node.")
+
+            nAttempt += 1
+            if nAttempt > 1:
+                logging.info("Wait 1 second.")
+                time.sleep(1)
+                logging.info("")
+
+            logging.info("Attempt #{0}.".format(nAttempt))
+            s1 = node.status()
+
+            if s1 == testgres.NodeStatus.Running:
+                continue
+
+            if s1 == testgres.NodeStatus.Stopped:
+                break
+
+            raise Exception("Unexpected node status: {0}.".format(s1))
+
+        logging.info("OK. Node is stopped.")
+        node.cleanup()
 
     def test_replicate(self):
         with get_new_node() as node:


### PR DESCRIPTION
LocalOperations::rmdirs
 - parameter 'retries' was remaned with 'attempts'
 - if ignore_errors we raise an error

RemoteOperations::rmdirs
 - parameter 'verbose' was removed
 - method returns bool
 - we prevent to delete a file