### PR TITLE
[remote_ops] A problem with mktemp on Alpine Linux is fixed

### DIFF
--- a/testgres/operations/remote_ops.py
+++ b/testgres/operations/remote_ops.py
@@ -316,7 +316,7 @@ class RemoteOperations(OsOperations):
         - prefix (str): The prefix of the temporary directory name.
         """
         if prefix:
-            command = ["mktemp", "-d", "-t", prefix + "XXXXX"]
+            command = ["mktemp", "-d", "-t", prefix + "XXXXXX"]
         else:
             command = ["mktemp", "-d"]
 
@@ -344,7 +344,7 @@ class RemoteOperations(OsOperations):
         - prefix (str): The prefix of the temporary directory name.
         """
         if prefix:
-            command = ["mktemp", "-t", prefix + "XXXXX"]
+            command = ["mktemp", "-t", prefix + "XXXXXX"]
         else:
             command = ["mktemp"]
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import re
 import tempfile
+import logging
 
 from ..testgres import ExecUtilException
 from ..testgres import InvalidOperationException
@@ -17,6 +18,22 @@ class TestLocalOperations:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self):
         self.operations = LocalOperations()
+
+    def test_mkdtemp__default(self):
+        path = self.operations.mkdtemp()
+        logging.info("Path is [{0}].".format(path))
+        assert os.path.exists(path)
+        os.rmdir(path)
+        assert not os.path.exists(path)
+
+    def test_mkdtemp__custom(self):
+        C_TEMPLATE = "abcdef"
+        path = self.operations.mkdtemp(C_TEMPLATE)
+        logging.info("Path is [{0}].".format(path))
+        assert os.path.exists(path)
+        assert C_TEMPLATE in os.path.basename(path)
+        os.rmdir(path)
+        assert not os.path.exists(path)
 
     def test_exec_command_success(self):
         """

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import re
 import tempfile
+import logging
 
 from ..testgres import ExecUtilException
 from ..testgres import InvalidOperationException
@@ -109,6 +110,22 @@ class TestRemoteOperations:
         # Test makedirs
         with pytest.raises(Exception):
             self.operations.makedirs(path)
+
+    def test_mkdtemp__default(self):
+        path = self.operations.mkdtemp()
+        logging.info("Path is [{0}].".format(path))
+        assert os.path.exists(path)
+        os.rmdir(path)
+        assert not os.path.exists(path)
+
+    def test_mkdtemp__custom(self):
+        C_TEMPLATE = "abcdef"
+        path = self.operations.mkdtemp(C_TEMPLATE)
+        logging.info("Path is [{0}].".format(path))
+        assert os.path.exists(path)
+        assert C_TEMPLATE in os.path.basename(path)
+        os.rmdir(path)
+        assert not os.path.exists(path)
 
     def test_rmdirs(self):
         path = self.operations.mkdtemp()


### PR DESCRIPTION
Five 'X' in template is not enough - Alpine returns "mktemp: : Invalid argument" error.

Six 'X' is OK.