### PR TITLE
Dockerfile for Ubuntu 2024.04 is updated

### DIFF
--- a/Dockerfile--ubuntu-24_04.tmpl
+++ b/Dockerfile--ubuntu-24_04.tmpl
@@ -55,4 +55,4 @@ ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -N ''; \
 cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys; \
 chmod 600 ~/.ssh/authorized_keys; \
 ls -la ~/.ssh/; \
-TEST_FILTER="" PYTHON_VERSION=${PYTHON_VERSION} bash run_tests.sh;"
+TEST_FILTER=\"\" PYTHON_VERSION=${PYTHON_VERSION} bash run_tests.sh;"

--- a/Dockerfile--ubuntu-24_04.tmpl
+++ b/Dockerfile--ubuntu-24_04.tmpl
@@ -37,33 +37,22 @@ RUN ssh-keygen -A
 RUN sh -c "echo postgres ALL=NOPASSWD:/usr/sbin/service ssh start" >> /etc/sudoers
 
 USER postgres
-
 ENV LANG=C.UTF-8
+
+RUN chmod 700 ~/
+RUN mkdir -p ~/.ssh
 
 #ENTRYPOINT PYTHON_VERSION=3.12 /run.sh
 ENTRYPOINT sh -c " \
 #set -eux; \
 echo HELLO FROM ENTRYPOINT; \
 echo HOME DIR IS [`realpath ~/`]; \
-echo POINT 1; \
-chmod go-w /var/lib/postgresql; \
-echo POINT 1.5; \
-mkdir -p ~/.ssh; \
-echo POINT 2; \
 service ssh enable; \
-echo POINT 3; \
 sudo service ssh start; \
-echo POINT 4; \
 ssh-keyscan -H localhost >> ~/.ssh/known_hosts; \
-echo POINT 5; \
 ssh-keyscan -H 127.0.0.1 >> ~/.ssh/known_hosts; \
-echo POINT 6; \
 ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -N ''; \
-echo ----; \
 cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys; \
-echo ----; \
 chmod 600 ~/.ssh/authorized_keys; \
-echo ----; \
 ls -la ~/.ssh/; \
-echo ----; \
 TEST_FILTER="" PYTHON_VERSION=${PYTHON_VERSION} bash run_tests.sh;"


### PR DESCRIPTION
- Using "chmod 700 ~/" instead "chmod go-w /var/lib/postgresql"
- "~/.ssh" folder is prepared at image level
- Entrypoint startup code is cleaned from trace messages