### PR TITLE
test_pg_ctl_wait_option is updated

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -438,6 +438,19 @@ class TestgresTests:
         nAttempt = 0
         while True:
             if nAttempt == C_MAX_ATTEMPTS:
+                #
+                # [2025-03-11]
+                #  We have an unexpected problem with this test in CI
+                #  Let's get an additional information about this test failure.
+                #
+                logging.error("Node was not stopped.")
+                if not node.os_ops.path_exists(node.pg_log_file):
+                    logging.warning("Node log does not exist.")
+                else:
+                    logging.info("Let's read node log file [{0}]".format(node.pg_log_file))
+                    logFileData = node.os_ops.read(node.pg_log_file, binary=False)
+                    logging.info("Node log file content:\n{0}".format(logFileData))
+
                 raise Exception("Could not stop node.")
 
             nAttempt += 1

--- a/tests/test_simple_remote.py
+++ b/tests/test_simple_remote.py
@@ -517,6 +517,19 @@ class TestgresRemoteTests:
         nAttempt = 0
         while True:
             if nAttempt == C_MAX_ATTEMPTS:
+                #
+                # [2025-03-11]
+                #  We have an unexpected problem with this test in CI
+                #  Let's get an additional information about this test failure.
+                #
+                logging.error("Node was not stopped.")
+                if not node.os_ops.path_exists(node.pg_log_file):
+                    logging.warning("Node log does not exist.")
+                else:
+                    logging.info("Let's read node log file [{0}]".format(node.pg_log_file))
+                    logFileData = node.os_ops.read(node.pg_log_file, binary=False)
+                    logging.info("Node log file content:\n{0}".format(logFileData))
+
                 raise Exception("Could not stop node.")
 
             nAttempt += 1


### PR DESCRIPTION
When node is not stopped, we read and output a content of node log file to provide an additional information about this problem.

It should help find a reason of an unexpected problem with this test in CI.