### PR TITLE
Initialization of Helpers._get_default_encoding_func is corrected [py3.9]

### DIFF
--- a/testgres/operations/helpers.py
+++ b/testgres/operations/helpers.py
@@ -12,7 +12,7 @@ class Helpers:
         return locale.getpreferredencoding
 
     # Prepared pointer on function to get a name of system codepage
-    _get_default_encoding_func = _make_get_default_encoding_func()
+    _get_default_encoding_func = _make_get_default_encoding_func.__func__()
 
     @staticmethod
     def GetDefaultEncoding():


### PR DESCRIPTION
Python 3.9 does not undestand the following code:

``` python
_get_default_encoding_func = _make_get_default_encoding_func()
```
> ERROR - TypeError: 'staticmethod' object is not callable

https://app.travis-ci.com/github/postgrespro/testgres/jobs/631402370

The code:
``` python
_get_default_encoding_func = _make_get_default_encoding_func.__func__()
```
is processed without problems.