### PR TITLE
Warnings with pytest are fixed

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = ["./tests", "./testgres/plugins/pg_probackup2/pg_probackup2/tests"]
+testpaths = tests testgres/plugins/pg_probackup2/pg_probackup2/tests
 addopts = --strict-markers
 markers =    
 #log_file = logs/pytest.log

--- a/tests/test_testgres_common.py
+++ b/tests/test_testgres_common.py
@@ -10,7 +10,11 @@ from ..testgres.utils import get_bin_path2
 from ..testgres import ProcessType
 from ..testgres import NodeStatus
 from ..testgres import IsolationLevel
-from ..testgres import TestgresException
+
+# New name prevents to collect test-functions in TestgresException and fixes
+# the problem with pytest warning.
+from ..testgres import TestgresException as testgres_TestgresException
+
 from ..testgres import InitNodeException
 from ..testgres import StartNodeException
 from ..testgres import QueryException
@@ -336,7 +340,7 @@ class TestTestgresCommon:
         with __class__.helper__get_node(os_ops).init().start() as master:
 
             # master node doesn't have a source walsender!
-            with pytest.raises(expected_exception=TestgresException):
+            with pytest.raises(expected_exception=testgres_TestgresException):
                 master.source_walsender
 
             with master.connect() as con:
@@ -366,7 +370,7 @@ class TestTestgresCommon:
                 replica.stop()
 
                 # there should be no walsender after we've stopped replica
-                with pytest.raises(expected_exception=TestgresException):
+                with pytest.raises(expected_exception=testgres_TestgresException):
                     replica.source_walsender
 
     def test_exceptions(self):
@@ -1013,7 +1017,7 @@ class TestTestgresCommon:
                 replica.execute('select 1')
 
                 # cannot create new slot with the same name
-                with pytest.raises(expected_exception=TestgresException):
+                with pytest.raises(expected_exception=testgres_TestgresException):
                     node.replicate(slot='slot1')
 
     def test_incorrect_catchup(self, os_ops: OsOperations):
@@ -1022,7 +1026,7 @@ class TestTestgresCommon:
             node.init(allow_streaming=True).start()
 
             # node has no master, can't catch up
-            with pytest.raises(expected_exception=TestgresException):
+            with pytest.raises(expected_exception=testgres_TestgresException):
                 node.catchup()
 
     def test_promotion(self, os_ops: OsOperations):


### PR DESCRIPTION
1) [pytest.ini] testpaths has another format. It is a spaces separated list.

pytest warning:
PytestConfigWarning: No files were found in testpaths; consider removing or adjusting your testpaths configuration. Searching recursively from the current directory instead.

2) pytest tries to find the test function in TestgresException class. Let's rename it to avoid this problem.

pytest warning:
PytestCollectionWarning: cannot collect test class 'TestgresException' because it has a __init__ constructor (from: tests/test_simple.py)
    class TestgresException(Exception):

Of course, we can add __test__=False in TestgresException but it is not a good solution.