### PR TITLE
[New] OsOps::execute_command supports a transfer of environment variables (exec_env)

### DIFF
--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1020,7 +1020,7 @@ class PostgresNode(object):
 
         return out_dict
 
-    def slow_start(self, replica=False, dbname='template1', username=None, max_attempts=0):
+    def slow_start(self, replica=False, dbname='template1', username=None, max_attempts=0, exec_env=None):
         """
         Starts the PostgreSQL instance and then polls the instance
         until it reaches the expected state (primary or replica). The state is checked
@@ -1033,7 +1033,9 @@ class PostgresNode(object):
                         If False, waits for the instance to be in primary mode. Default is False.
                max_attempts:
         """
-        self.start()
+        assert exec_env is None or type(exec_env) == dict  # noqa: E721
+
+        self.start(exec_env=exec_env)
 
         if replica:
             query = 'SELECT pg_is_in_recovery()'
@@ -1065,7 +1067,7 @@ class PostgresNode(object):
                 return True
         return False
 
-    def start(self, params=[], wait=True):
+    def start(self, params=[], wait=True, exec_env=None):
         """
         Starts the PostgreSQL node using pg_ctl if node has not been started.
         By default, it waits for the operation to complete before returning.
@@ -1079,7 +1081,7 @@ class PostgresNode(object):
         Returns:
             This instance of :class:`.PostgresNode`.
         """
-
+        assert exec_env is None or type(exec_env) == dict  # noqa: E721
         assert __class__._C_MAX_START_ATEMPTS > 1
 
         if self.is_started:
@@ -1098,7 +1100,7 @@ class PostgresNode(object):
 
         def LOCAL__start_node():
             # 'error' will be None on Windows
-            _, _, error = execute_utility2(self.os_ops, _params, self.utils_log_file, verbose=True)
+            _, _, error = execute_utility2(self.os_ops, _params, self.utils_log_file, verbose=True, exec_env=exec_env)
             assert error is None or type(error) == str  # noqa: E721
             if error and 'does not exist' in error:
                 raise Exception(error)

--- a/testgres/utils.py
+++ b/testgres/utils.py
@@ -96,17 +96,26 @@ def execute_utility(args, logfile=None, verbose=False):
     return execute_utility2(tconf.os_ops, args, logfile, verbose)
 
 
-def execute_utility2(os_ops: OsOperations, args, logfile=None, verbose=False, ignore_errors=False):
+def execute_utility2(
+        os_ops: OsOperations,
+        args,
+        logfile=None,
+        verbose=False,
+        ignore_errors=False,
+        exec_env=None,
+):
     assert os_ops is not None
     assert isinstance(os_ops, OsOperations)
     assert type(verbose) == bool  # noqa: E721
     assert type(ignore_errors) == bool  # noqa: E721
+    assert exec_env is None or type(exec_env) == dict  # noqa: E721
 
     exit_status, out, error = os_ops.exec_command(
         args,
         verbose=True,
         ignore_errors=ignore_errors,
-        encoding=OsHelpers.GetDefaultEncoding())
+        encoding=OsHelpers.GetDefaultEncoding(),
+        exec_env=exec_env)
 
     out = '' if not out else out
 

--- a/tests/test_os_ops_common.py
+++ b/tests/test_os_ops_common.py
@@ -98,7 +98,7 @@ class TestOsOpsCommon:
 
         RunConditions.skip_if_windows()
 
-        C_ENV_NAME = "EXEC_TEST_TESTGRES_ENV_1975"
+        C_ENV_NAME = "TESTGRES_TEST__EXEC_ENV_20250414"
 
         cmd = ["sh", "-c", "echo ${}".format(C_ENV_NAME)]
 
@@ -147,7 +147,7 @@ class TestOsOpsCommon:
 
         RunConditions.skip_if_windows()
 
-        C_ENV_NAME = "IT_IS_A_TEST_DUMMY_VAR"
+        C_ENV_NAME = "TESTGRES_TEST__DUMMY_VAR_20250414"
 
         cmd = ["sh", "-c", "echo ${}".format(C_ENV_NAME)]
 

--- a/tests/test_os_ops_common.py
+++ b/tests/test_os_ops_common.py
@@ -93,6 +93,70 @@ class TestOsOpsCommon:
         assert b"nonexistent_command" in error
         assert b"not found" in error
 
+    def test_exec_command_with_exec_env(self, os_ops: OsOperations):
+        assert isinstance(os_ops, OsOperations)
+
+        RunConditions.skip_if_windows()
+
+        C_ENV_NAME = "EXEC_TEST_TESTGRES_ENV_1975"
+
+        cmd = ["sh", "-c", "echo ${}".format(C_ENV_NAME)]
+
+        exec_env = {C_ENV_NAME: "Hello!"}
+
+        response = os_ops.exec_command(cmd, exec_env=exec_env)
+        assert response is not None
+        assert type(response) == bytes  # noqa: E721
+        assert response == b'Hello!\n'
+
+        response = os_ops.exec_command(cmd)
+        assert response is not None
+        assert type(response) == bytes  # noqa: E721
+        assert response == b'\n'
+
+    def test_exec_command__test_unset(self, os_ops: OsOperations):
+        assert isinstance(os_ops, OsOperations)
+
+        RunConditions.skip_if_windows()
+
+        C_ENV_NAME = "LANG"
+
+        cmd = ["sh", "-c", "echo ${}".format(C_ENV_NAME)]
+
+        response1 = os_ops.exec_command(cmd)
+        assert response1 is not None
+        assert type(response1) == bytes  # noqa: E721
+
+        if response1 == b'\n':
+            logging.warning("Environment variable {} is not defined.".format(C_ENV_NAME))
+            return
+
+        exec_env = {C_ENV_NAME: None}
+        response2 = os_ops.exec_command(cmd, exec_env=exec_env)
+        assert response2 is not None
+        assert type(response2) == bytes  # noqa: E721
+        assert response2 == b'\n'
+
+        response3 = os_ops.exec_command(cmd)
+        assert response3 is not None
+        assert type(response3) == bytes  # noqa: E721
+        assert response3 == response1
+
+    def test_exec_command__test_unset_dummy_var(self, os_ops: OsOperations):
+        assert isinstance(os_ops, OsOperations)
+
+        RunConditions.skip_if_windows()
+
+        C_ENV_NAME = "IT_IS_A_TEST_DUMMY_VAR"
+
+        cmd = ["sh", "-c", "echo ${}".format(C_ENV_NAME)]
+
+        exec_env = {C_ENV_NAME: None}
+        response2 = os_ops.exec_command(cmd, exec_env=exec_env)
+        assert response2 is not None
+        assert type(response2) == bytes  # noqa: E721
+        assert response2 == b'\n'
+
     def test_is_executable_true(self, os_ops: OsOperations):
         """
         Test is_executable for an existing executable.


### PR DESCRIPTION
New feature allows to pass environment variables to an executed program.

If variable in exec_env has None value, then this variable will be unset.

A support of exec_env is added to PostgresNode::start and PostgresNode::slow_start.

This feature is required for internal test projects...