### PR TITLE
[FIX] Tests include testgres by right way through import

### DIFF
--- a/testgres/plugins/pg_probackup2/pg_probackup2/tests/test_basic.py
+++ b/testgres/plugins/pg_probackup2/pg_probackup2/tests/test_basic.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import pytest
 
-from ...... import testgres
+import testgres
 from ...pg_probackup2.app import ProbackupApp
 from ...pg_probackup2.init_helpers import Init, init_params
 from ..storage.fs_backup import FSTestBackupDir

--- a/tests/helpers/global_data.py
+++ b/tests/helpers/global_data.py
@@ -1,11 +1,11 @@
-from ...testgres.operations.os_ops import OsOperations
-from ...testgres.operations.os_ops import ConnectionParams
-from ...testgres.operations.local_ops import LocalOperations
-from ...testgres.operations.remote_ops import RemoteOperations
+from testgres.operations.os_ops import OsOperations
+from testgres.operations.os_ops import ConnectionParams
+from testgres.operations.local_ops import LocalOperations
+from testgres.operations.remote_ops import RemoteOperations
 
-from ...testgres.node import PortManager
-from ...testgres.node import PortManager__ThisHost
-from ...testgres.node import PortManager__Generic
+from testgres.node import PortManager
+from testgres.node import PortManager__ThisHost
+from testgres.node import PortManager__Generic
 
 import os
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,9 @@
-from ..testgres import TestgresConfig
-from ..testgres import configure_testgres
-from ..testgres import scoped_config
-from ..testgres import pop_config
+from testgres import TestgresConfig
+from testgres import configure_testgres
+from testgres import scoped_config
+from testgres import pop_config
 
-from .. import testgres
+import testgres
 
 import pytest
 

--- a/tests/test_os_ops_common.py
+++ b/tests/test_os_ops_common.py
@@ -14,8 +14,8 @@ import socket
 import threading
 import typing
 
-from ..testgres import InvalidOperationException
-from ..testgres import ExecUtilException
+from testgres import InvalidOperationException
+from testgres import ExecUtilException
 
 
 class TestOsOpsCommon:

--- a/tests/test_os_ops_remote.py
+++ b/tests/test_os_ops_remote.py
@@ -3,7 +3,7 @@
 from .helpers.global_data import OsOpsDescrs
 from .helpers.global_data import OsOperations
 
-from ..testgres import ExecUtilException
+from testgres import ExecUtilException
 
 import os
 import pytest

--- a/tests/test_testgres_common.py
+++ b/tests/test_testgres_common.py
@@ -3,29 +3,29 @@ from .helpers.global_data import PostgresNodeServices
 from .helpers.global_data import OsOperations
 from .helpers.global_data import PortManager
 
-from ..testgres.node import PgVer
-from ..testgres.node import PostgresNode
-from ..testgres.utils import get_pg_version2
-from ..testgres.utils import file_tail
-from ..testgres.utils import get_bin_path2
-from ..testgres import ProcessType
-from ..testgres import NodeStatus
-from ..testgres import IsolationLevel
+from testgres.node import PgVer
+from testgres.node import PostgresNode
+from testgres.utils import get_pg_version2
+from testgres.utils import file_tail
+from testgres.utils import get_bin_path2
+from testgres import ProcessType
+from testgres import NodeStatus
+from testgres import IsolationLevel
 
 # New name prevents to collect test-functions in TestgresException and fixes
 # the problem with pytest warning.
-from ..testgres import TestgresException as testgres_TestgresException
+from testgres import TestgresException as testgres_TestgresException
 
-from ..testgres import InitNodeException
-from ..testgres import StartNodeException
-from ..testgres import QueryException
-from ..testgres import ExecUtilException
-from ..testgres import TimeoutException
-from ..testgres import InvalidOperationException
-from ..testgres import BackupException
-from ..testgres import ProgrammingError
-from ..testgres import scoped_config
-from ..testgres import First, Any
+from testgres import InitNodeException
+from testgres import StartNodeException
+from testgres import QueryException
+from testgres import ExecUtilException
+from testgres import TimeoutException
+from testgres import InvalidOperationException
+from testgres import BackupException
+from testgres import ProgrammingError
+from testgres import scoped_config
+from testgres import First, Any
 
 from contextlib import contextmanager
 

--- a/tests/test_testgres_local.py
+++ b/tests/test_testgres_local.py
@@ -7,21 +7,21 @@ import psutil
 import platform
 import logging
 
-from .. import testgres
+import testgres
 
-from ..testgres import StartNodeException
-from ..testgres import ExecUtilException
-from ..testgres import NodeApp
-from ..testgres import scoped_config
-from ..testgres import get_new_node
-from ..testgres import get_bin_path
-from ..testgres import get_pg_config
-from ..testgres import get_pg_version
+from testgres import StartNodeException
+from testgres import ExecUtilException
+from testgres import NodeApp
+from testgres import scoped_config
+from testgres import get_new_node
+from testgres import get_bin_path
+from testgres import get_pg_config
+from testgres import get_pg_version
 
 # NOTE: those are ugly imports
-from ..testgres.utils import bound_ports
-from ..testgres.utils import PgVer
-from ..testgres.node import ProcessProxy
+from testgres.utils import bound_ports
+from testgres.utils import PgVer
+from testgres.node import ProcessProxy
 
 
 def pg_version_ge(version):

--- a/tests/test_testgres_remote.py
+++ b/tests/test_testgres_remote.py
@@ -7,16 +7,16 @@ import logging
 from .helpers.global_data import PostgresNodeService
 from .helpers.global_data import PostgresNodeServices
 
-from .. import testgres
+import testgres
 
-from ..testgres.exceptions import InitNodeException
-from ..testgres.exceptions import ExecUtilException
+from testgres.exceptions import InitNodeException
+from testgres.exceptions import ExecUtilException
 
-from ..testgres.config import scoped_config
-from ..testgres.config import testgres_config
+from testgres.config import scoped_config
+from testgres.config import testgres_config
 
-from ..testgres import get_bin_path
-from ..testgres import get_pg_config
+from testgres import get_bin_path
+from testgres import get_pg_config
 
 # NOTE: those are ugly imports
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,9 @@ from .helpers.global_data import OsOpsDescr
 from .helpers.global_data import OsOpsDescrs
 from .helpers.global_data import OsOperations
 
-from ..testgres.utils import parse_pg_version
-from ..testgres.utils import get_pg_config2
-from ..testgres import scoped_config
+from testgres.utils import parse_pg_version
+from testgres.utils import get_pg_config2
+from testgres import scoped_config
 
 import pytest
 import typing


### PR DESCRIPTION
When we do not have root `__init__.py`, tests must to import testgres through
``` py
import testgres
```

not through
``` py
from relative_path import testgres
```

It fixes a problem with this commit - 6e5e4f5a9eb7f7a02df7056dcded7e0b68a6d1da