### PR TITLE
[#249] Fix of port number leak in NodeBackup::spawn_replica

### DIFF
--- a/testgres/backup.py
+++ b/testgres/backup.py
@@ -184,14 +184,19 @@ class NodeBackup(object):
         """
 
         # Build a new PostgresNode
-        with clean_on_error(self.spawn_primary(name=name,
-                                               destroy=destroy)) as node:
+        node = self.spawn_primary(name=name, destroy=destroy)
+        assert node is not None
 
+        try:
             # Assign it a master and a recovery file (private magic)
             node._assign_master(self.original_node)
             node._create_recovery_conf(username=self.username, slot=slot)
+        except:  # noqa: E722
+            # TODO: Pass 'final=True' ?
+            node.cleanup(release_resources=True)
+            raise
 
-            return node
+        return node
 
     def cleanup(self):
         """

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -244,7 +244,7 @@ class PostgresNode(object):
         else:
             self._try_shutdown(attempts)
 
-        self.free_port()
+        self._release_resources()
 
     def __repr__(self):
         return "{}(name='{}', port={}, base_dir='{}')".format(
@@ -662,6 +662,9 @@ class PostgresNode(object):
         __class__._throw_bugcheck__unexpected_result_of_ps(
             ps_output,
             ps_command)
+
+    def _release_resources(self):
+        self.free_port()
 
     @staticmethod
     def _throw_bugcheck__unexpected_result_of_ps(result, cmd):

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -231,8 +231,6 @@ class PostgresNode(object):
         return self
 
     def __exit__(self, type, value, traceback):
-        self.free_port()
-
         # NOTE: Ctrl+C does not count!
         got_exception = type is not None and type != KeyboardInterrupt
 
@@ -245,6 +243,8 @@ class PostgresNode(object):
             self.cleanup(attempts)
         else:
             self._try_shutdown(attempts)
+
+        self.free_port()
 
     def __repr__(self):
         return "{}(name='{}', port={}, base_dir='{}')".format(

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -1343,7 +1343,7 @@ class PostgresNode(object):
             self._port = None
             self._port_manager.release_port(port)
 
-    def cleanup(self, max_attempts=3, full=False):
+    def cleanup(self, max_attempts=3, full=False, release_resources=False):
         """
         Stop node if needed and remove its data/logs directory.
         NOTE: take a look at TestgresConfig.node_cleanup_full.
@@ -1365,6 +1365,9 @@ class PostgresNode(object):
             rm_dir = self.data_dir    # just data, save logs
 
         self.os_ops.rmdirs(rm_dir, ignore_errors=False)
+
+        if release_resources:
+            self._release_resources()
 
         return self
 


### PR DESCRIPTION
This patch has the following changes:

1) It adds a new argument release_resources to PostgresNode::cleanup method. Default value is False.

2) It fixes a port number leak in NodeBackup::spawn_replica through explicit call of PostgresNode::cleanup(release_resources=True).

Closes #249.