### PR TITLE
LocalOperations::get_single_instance is added

### DIFF
--- a/testgres/cache.py
+++ b/testgres/cache.py
@@ -22,12 +22,16 @@ from .operations.local_ops import LocalOperations
 from .operations.os_ops import OsOperations
 
 
-def cached_initdb(data_dir, logfile=None, params=None, os_ops: OsOperations = LocalOperations(), bin_path=None, cached=True):
+def cached_initdb(data_dir, logfile=None, params=None, os_ops: OsOperations = None, bin_path=None, cached=True):
     """
     Perform initdb or use cached node files.
     """
 
-    assert os_ops is not None
+    assert os_ops is None or isinstance(os_ops, OsOperations)
+
+    if os_ops is None:
+        os_ops = LocalOperations.get_single_instance()
+
     assert isinstance(os_ops, OsOperations)
 
     def make_utility_path(name):

--- a/testgres/config.py
+++ b/testgres/config.py
@@ -50,8 +50,9 @@ class GlobalConfig(object):
     _cached_initdb_dir = None
     """ underlying class attribute for cached_initdb_dir property """
 
-    os_ops = LocalOperations()
+    os_ops = LocalOperations.get_single_instance()
     """ OsOperation object that allows work on remote host """
+
     @property
     def cached_initdb_dir(self):
         """ path to a temp directory for cached initdb. """

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -93,6 +93,8 @@ from .pubsub import Publication, Subscription
 
 from .standby import First
 
+from . import utils
+
 from .utils import \
     PgVer, \
     eprint, \
@@ -265,14 +267,17 @@ class PostgresNode(object):
         if testgres_config.os_ops:
             return testgres_config.os_ops
 
-        return LocalOperations()
+        return LocalOperations.get_single_instance()
 
     @staticmethod
     def _get_port_manager(os_ops: OsOperations) -> PortManager:
         assert os_ops is not None
         assert isinstance(os_ops, OsOperations)
 
-        if isinstance(os_ops, LocalOperations):
+        if os_ops is LocalOperations.get_single_instance():
+            assert utils._old_port_manager is not None
+            assert type(utils._old_port_manager) == PortManager__Generic
+            assert utils._old_port_manager._os_ops is os_ops
             return PortManager__ThisHost.get_single_instance()
 
         # TODO: Throw the exception "Please define a port manager." ?
@@ -816,10 +821,13 @@ class PostgresNode(object):
         """
 
         # initialize this PostgreSQL node
+        assert self._os_ops is not None
+        assert isinstance(self._os_ops, OsOperations)
+
         cached_initdb(
             data_dir=self.data_dir,
             logfile=self.utils_log_file,
-            os_ops=self.os_ops,
+            os_ops=self._os_ops,
             params=initdb_params,
             bin_path=self.bin_dir,
             cached=False)
@@ -2186,7 +2194,14 @@ class PostgresNode(object):
 
 class NodeApp:
 
-    def __init__(self, test_path=None, nodes_to_cleanup=None, os_ops=LocalOperations()):
+    def __init__(self, test_path=None, nodes_to_cleanup=None, os_ops=None):
+        assert os_ops is None or isinstance(os_ops, OsOperations)
+
+        if os_ops is None:
+            os_ops = LocalOperations.get_single_instance()
+
+        assert isinstance(os_ops, OsOperations)
+
         if test_path:
             if os.path.isabs(test_path):
                 self.test_path = test_path

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -276,7 +276,7 @@ class PostgresNode(object):
 
         if os_ops is LocalOperations.get_single_instance():
             assert utils._old_port_manager is not None
-            assert type(utils._old_port_manager) == PortManager__Generic
+            assert type(utils._old_port_manager) == PortManager__Generic  # noqa: E721
             assert utils._old_port_manager._os_ops is os_ops
             return PortManager__ThisHost.get_single_instance()
 

--- a/testgres/utils.py
+++ b/testgres/utils.py
@@ -25,12 +25,10 @@ from .impl.port_manager__generic import PortManager__Generic
 # rows returned by PG_CONFIG
 _pg_config_data = {}
 
-_local_operations = LocalOperations()
-
 #
 # The old, global "port manager" always worked with LOCAL system
 #
-_old_port_manager = PortManager__Generic(_local_operations)
+_old_port_manager = PortManager__Generic(LocalOperations.get_single_instance())
 
 # ports used by nodes
 bound_ports = _old_port_manager._reserved_ports

--- a/tests/helpers/global_data.py
+++ b/tests/helpers/global_data.py
@@ -31,7 +31,7 @@ class OsOpsDescrs:
 
     sm_remote_os_ops_descr = OsOpsDescr("remote_ops", sm_remote_os_ops)
 
-    sm_local_os_ops = LocalOperations()
+    sm_local_os_ops = LocalOperations.get_single_instance()
 
     sm_local_os_ops_descr = OsOpsDescr("local_ops", sm_local_os_ops)
 


### PR DESCRIPTION
This patch forces testgres to use a single instance of LocalOperations that is created with default parameters.

Note that, PortManager__ThisHost is used only when PostgresNode uses this single local_ops instance.

It is part of work for #247 [refactoring stage]