### PR TITLE
[#235] test_pg_ctl_wait_option detects a port conflict

### DIFF
--- a/testgres/node.py
+++ b/testgres/node.py
@@ -2245,7 +2245,7 @@ class PostgresNodeLogReader:
             assert type(file_content_b) == bytes  # noqa: E721
 
             #
-            # A POTENTIAL PROBLEM: file_content_b may contain an incompeted UTF-8 symbol.
+            # A POTENTIAL PROBLEM: file_content_b may contain an incompleted UTF-8 symbol.
             #
             file_content_s = file_content_b.decode()
             assert type(file_content_s) == str  # noqa: E721


### PR DESCRIPTION
This commit must fix a problem in test_pg_ctl_wait_option when his PostgreSQL instance conflicts with another one.

For this, we added two new things:
 - PostgresNodeLogReader
 - PostgresNodeUtils

PostgresNodeLogReader reads server logs.

PostgresNodeUtils provides an utility to detect a port conflict.

PostgresNode::start also uses these new classes.