### PR TITLE
[#274] Unused should_rm_dirs is deleted (cleanup)

### DIFF
--- a/testgres/backup.py
+++ b/testgres/backup.py
@@ -163,10 +163,6 @@ class NodeBackup(object):
         assert type(node) == self.original_node.__class__  # noqa: E721
 
         with clean_on_error(node) as node:
-
-            # New nodes should always remove dir tree
-            node._should_rm_dirs = True
-
             # Set a new port
             node.append_conf(filename=PG_CONF_FILE, line='\n')
             node.append_conf(filename=PG_CONF_FILE, port=node.port)

--- a/testgres/node.py
+++ b/testgres/node.py
@@ -2384,7 +2384,6 @@ class NodeApp:
         self.os_ops.makedirs(real_base_dir)
 
         node = PostgresNode(base_dir=real_base_dir, port=port, bin_dir=bin_dir)
-        node.should_rm_dirs = True
         self.nodes_to_cleanup.append(node)
 
         return node


### PR DESCRIPTION
This strange PostgresNode property is not documented and is not used in Testgres code.