### PR TITLE
[python v3.13] TestTestgresCommon::test_logging uses logging._lock

### DIFF
--- a/tests/test_testgres_common.py
+++ b/tests/test_testgres_common.py
@@ -622,13 +622,12 @@ class TestTestgresCommon:
                         assert (master._logger.is_alive())
             finally:
                 # It is a hack code to logging cleanup
-                logging._acquireLock()
-                assert logging.Logger.manager is not None
-                assert C_NODE_NAME in logging.Logger.manager.loggerDict.keys()
-                logging.Logger.manager.loggerDict.pop(C_NODE_NAME, None)
-                assert not (C_NODE_NAME in logging.Logger.manager.loggerDict.keys())
-                assert not (handler in logging._handlers.values())
-                logging._releaseLock()
+                with logging._lock:
+                    assert logging.Logger.manager is not None
+                    assert C_NODE_NAME in logging.Logger.manager.loggerDict.keys()
+                    logging.Logger.manager.loggerDict.pop(C_NODE_NAME, None)
+                    assert not (C_NODE_NAME in logging.Logger.manager.loggerDict.keys())
+                    assert not (handler in logging._handlers.values())
         # GO HOME!
         return
 


### PR DESCRIPTION
Python 3.13 deleted the following internal functions:
 - logging._acquireLock()
 - logging._releaseLock()

See https://github.com/python/cpython/commit/74723e11109a320e628898817ab449b3dad9ee96 (Sep 27, 2023)

logging._lock was not touched.

So, we use "with logging._lock" instead this pair of deleted function.

Patch was tested with python v3.8.0