### PR TITLE
exceptions: fixed typo

### DIFF
--- a/testgres/exceptions.py
+++ b/testgres/exceptions.py
@@ -29,7 +29,7 @@ class ExecUtilException(TestgresException):
             msg.append(self.message)
 
         if self.command:
-            command_s = ' '.join(self.command) if isinstance(self.command, list) else self.command,
+            command_s = ' '.join(self.command) if isinstance(self.command, list) else self.command
             msg.append(u'Command: {}'.format(command_s))
 
         if self.exit_code:


### PR DESCRIPTION
It is implied that command_s should be a string, but now it is a tuple due to a typo.
Signed-off-by: Maksim Korotkov <m.korotkov@postgrespro.ru>