### PR TITLE
PostgresNode::slow_start and tests are updated

### DIFF
--- a/tests/test_testgres_local.py
+++ b/tests/test_testgres_local.py
@@ -12,6 +12,7 @@ import src as testgres
 from src import StartNodeException
 from src import ExecUtilException
 from src import NodeApp
+from src import NodeStatus
 from src import scoped_config
 from src import get_new_node
 from src import get_bin_path
@@ -316,7 +317,7 @@ class TestTestgresLocal:
                     assert (node2.port == node1.port)
 
                     node2.init()
-
+                    assert (node2.status() == NodeStatus.Stopped)
                     with pytest.raises(
                         expected_exception=StartNodeException,
                         match=re.escape("Cannot start node after multiple attempts.")
@@ -327,7 +328,8 @@ class TestTestgresLocal:
                     assert (node2._should_free_port)
                     assert (__class__.tagPortManagerProxy.sm_DummyPortCurrentUsage == 1)
                     assert (__class__.tagPortManagerProxy.sm_DummyPortTotalUsage == C_COUNT_OF_BAD_PORT_USAGE)
-                    assert not (node2.is_started)
+                    assert (not node2.is_started)
+                    assert (node2.status() == NodeStatus.Stopped)
 
                 # node2 must release our dummyPort (node1.port)
                 assert (__class__.tagPortManagerProxy.sm_DummyPortCurrentUsage == 0)
@@ -335,6 +337,7 @@ class TestTestgresLocal:
             # node1 is still working
             assert (node1.port == node1_port_copy)
             assert (node1._should_free_port)
+            assert (node1.status() == NodeStatus.Running)
             assert (rm_carriage_returns(node1.safe_psql("SELECT 3;")) == b'3\n')
 
     def test_simple_with_bin_dir(self):


### PR DESCRIPTION
### Main
1) PostgresNode::slow_start stops a node if it fails to wait for finish of initialization.

2) TestTestgresCommon::test_node_app__make_empty_with_explicit_port is rewritten.

### List of changes
1) PostgresNode::slow_start stops a node if it fails to wait for finish of initialization. Client expects to have fully started node.

2) TestTestgresLocal::test_port_conflict is updated. Checks of node statuses are added.

3) TestTestgresCommon::test_double_start is updated. Checks of node statuses are added.

4) TestTestgresCommon::test_uninitialized_start is updated. Checks of node statuses are added.

5) TestTestgresCommon::test_restart is updated. Checks of node statuses are added.

6) TestTestgresCommon::test_the_same_port is updated. Normalization. Checks of node statuses are added.

7) TestTestgresCommon::test_node_app__make_empty_with_explicit_port is rewritten. It does 5 attempts to start a node with a manually defined port number.