### PR TITLE
fix: get_remote_node is corrected

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -31,6 +31,10 @@ PostgresNode(name='...', port=..., base_dir='...')
 [(3,)]
 """
 from .node import PostgresNode
+from testgres.operations.remote_ops import ConnectionParams
+from testgres.operations.remote_ops import RemoteOperations
+
+import typing
 
 
 def get_new_node(name=None, base_dir=None, **kwargs):
@@ -42,11 +46,16 @@ def get_new_node(name=None, base_dir=None, **kwargs):
     return PostgresNode(name=name, base_dir=base_dir, **kwargs)
 
 
-def get_remote_node(name=None, conn_params=None):
+def get_remote_node(name=None, conn_params: typing.Optional[ConnectionParams] = None):
     """
     Simply a wrapper around :class:`.PostgresNode` constructor for remote node.
     See :meth:`.PostgresNode.__init__` for details.
     For remote connection you can add the next parameter:
     conn_params = ConnectionParams(host='127.0.0.1', ssh_key=None, username=default_username())
     """
-    return get_new_node(name=name, conn_params=conn_params)
+
+    if conn_params is None:
+        raise ValueError("Argument 'conn_params' is None.")
+
+    os_ops = RemoteOperations(conn_params)
+    return PostgresNode(name=name, os_ops=os_ops)


### PR DESCRIPTION
PostgresNode has not worked with ConnectionParams for a long time.