### PR TITLE
dockerfiles: default value of PYTHON_VERSION is defined (3/3.12)

### DIFF
--- a/Dockerfile--altlinux_10.tmpl
+++ b/Dockerfile--altlinux_10.tmpl
@@ -1,5 +1,5 @@
 ARG PG_VERSION
-ARG PYTHON_VERSION 
+ARG PYTHON_VERSION=3
 
 # --------------------------------------------- base1
 FROM alt:p10 AS base1

--- a/Dockerfile--altlinux_11.tmpl
+++ b/Dockerfile--altlinux_11.tmpl
@@ -1,5 +1,5 @@
 ARG PG_VERSION
-ARG PYTHON_VERSION 
+ARG PYTHON_VERSION=3
 
 # --------------------------------------------- base1
 FROM alt:p11 AS base1

--- a/Dockerfile--astralinux_1_7.tmpl
+++ b/Dockerfile--astralinux_1_7.tmpl
@@ -1,5 +1,5 @@
 ARG PG_VERSION
-ARG PYTHON_VERSION 
+ARG PYTHON_VERSION=3
 
 # --------------------------------------------- base1
 FROM packpack/packpack:astra-1.7 AS base1

--- a/Dockerfile--std-all.tmpl
+++ b/Dockerfile--std-all.tmpl
@@ -1,5 +1,5 @@
 ARG PG_VERSION
-ARG PYTHON_VERSION 
+ARG PYTHON_VERSION=3
 
 # --------------------------------------------- base1
 FROM postgres:${PG_VERSION}-alpine AS base1

--- a/Dockerfile--std.tmpl
+++ b/Dockerfile--std.tmpl
@@ -1,5 +1,5 @@
 ARG PG_VERSION
-ARG PYTHON_VERSION 
+ARG PYTHON_VERSION=3
 
 # --------------------------------------------- base1
 FROM postgres:${PG_VERSION}-alpine AS base1

--- a/Dockerfile--std2-all.tmpl
+++ b/Dockerfile--std2-all.tmpl
@@ -1,5 +1,5 @@
 ARG PG_VERSION
-ARG PYTHON_VERSION 
+ARG PYTHON_VERSION=3.12
 
 # --------------------------------------------- base1
 FROM postgres:${PG_VERSION}-alpine AS base1

--- a/Dockerfile--ubuntu_24_04.tmpl
+++ b/Dockerfile--ubuntu_24_04.tmpl
@@ -1,5 +1,5 @@
 ARG PG_VERSION
-ARG PYTHON_VERSION 
+ARG PYTHON_VERSION=3
 
 # --------------------------------------------- base1
 FROM ubuntu:24.04 AS base1


### PR DESCRIPTION
It fixes a docker warning like:

```
InvalidDefaultArgInFrom: Default value for ARG base2_with_python-${PYTHON_VERSION} results in empty or invalid base image name
```