### PR TITLE
[PostgresNode] utils_log_name and pg_log_name are RO-properties now

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -249,10 +249,6 @@ class PostgresNode(object):
         self.cleanup_on_bad_exit = testgres_config.node_cleanup_on_bad_exit
         self.shutdown_max_attempts = 3
 
-        # NOTE: for compatibility
-        self.utils_log_name = self.utils_log_file
-        self.pg_log_name = self.pg_log_file
-
         # Node state
         self._manually_started_pm_pid = None
 
@@ -539,6 +535,16 @@ class PostgresNode(object):
         path = self._os_ops.build_path(self.logs_dir, PG_LOG_FILE)
         assert type(path) is str
         return path
+
+    # NOTE: for compatibility
+    @property
+    def utils_log_name(self) -> str:
+        return self.utils_log_file
+
+    # NOTE: for compatibility
+    @property
+    def pg_log_name(self) -> str:
+        return self.pg_log_file
 
     @property
     def version(self):
@@ -1620,7 +1626,7 @@ class PostgresNode(object):
 
         # try pg_restore if dump is binary format, and psql if not
         try:
-            execute_utility2(self._os_ops, _params, self.utils_log_name)
+            execute_utility2(self._os_ops, _params, self.utils_log_file)
         except ExecUtilException:
             self.psql(filename=filename, dbname=dbname, username=username)
 

--- a/tests/test_testgres_common.py
+++ b/tests/test_testgres_common.py
@@ -132,6 +132,18 @@ class TestTestgresCommon:
             assert (isinstance(node.version, PgVer))
             assert (node.version == PgVer(version))
 
+    def test_node_constructor__default(self):
+        node = PostgresNode()
+        assert node._os_ops is not None
+        assert isinstance(node._os_ops, OsOperations)
+        assert node._port_manager is not None
+        assert isinstance(node._port_manager, PortManager)
+        assert node._name is not None
+        assert type(node._name) is str
+        assert node._name != ""
+        assert node._base_dir is None
+        return
+
     def test_node_repr(self, node_svc: PostgresNodeService):
         with __class__.helper__get_node(node_svc).init() as node:
             pattern = r"PostgresNode\(name='.+', port=.+, base_dir='.+'\)"


### PR DESCRIPTION
It prevents to create base_dir in constructor

Also:
 - PostgresNode::restore uses self.utils_log_file
 - TestTestgresCommon::test_node_constructor__default is added