### PR TITLE
fix: default_username does not respect os_ops

### DIFF
--- a/src/connection.py
+++ b/src/connection.py
@@ -14,7 +14,7 @@ from .enums import IsolationLevel
 
 from .defaults import \
     default_dbname, \
-    default_username
+    default_username2
 
 from .exceptions import QueryException
 
@@ -38,7 +38,7 @@ class NodeConnection(object):
 
         # Set default arguments
         dbname = dbname or default_dbname()
-        username = username or default_username()
+        username = username or default_username2(node.os_ops)
 
         self._node = node
 

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -1,6 +1,9 @@
 import datetime
 import struct
 import uuid
+import typing
+
+from testgres.operations.os_ops import OsOperations
 
 from .config import testgres_config as tconf
 
@@ -13,11 +16,30 @@ def default_dbname():
     return 'postgres'
 
 
-def default_username():
+def default_username(os_ops: typing.Optional[OsOperations] = None) -> str:
     """
     Return default username (current user).
     """
-    return tconf.os_ops.get_user()
+    assert os_ops is None or isinstance(os_ops, OsOperations)
+
+    if os_ops is None:
+        os_ops = tconf.os_ops
+
+    assert isinstance(os_ops, OsOperations)
+    result = default_username2(os_ops)
+    assert type(result) is str
+    return result
+
+
+def default_username2(os_ops: OsOperations) -> str:
+    """
+    Return default username (current user).
+    """
+    assert isinstance(os_ops, OsOperations)
+
+    result = os_ops.get_user()
+    assert type(result) is str
+    return result
 
 
 def generate_app_name():

--- a/src/pubsub.py
+++ b/src/pubsub.py
@@ -45,7 +45,7 @@ PostgresNode(name='...', port=..., base_dir='...')
 from six import raise_from
 
 from .consts import LOGICAL_REPL_MAX_CATCHUP_ATTEMPTS
-from .defaults import default_dbname, default_username
+from .defaults import default_dbname, default_username2
 from .exceptions import CatchUpException
 from .utils import options_string
 
@@ -72,7 +72,7 @@ class Publication(object):
         self.name = name
         self.node = node
         self.dbname = dbname or default_dbname()
-        self.username = username or default_username()
+        self.username = username or default_username2(node.os_ops)
 
         # create publication in database
         t = "table " + ", ".join(tables) if tables else "all tables"
@@ -167,7 +167,7 @@ class Subscription(object):
         self.node = node
         self.pub = publication
         self.dbname = dbname or default_dbname()
-        self.username = username or default_username()
+        self.username = username or default_username2(node.os_ops)
 
         # connection info
         conninfo = {

--- a/tests/test_testgres_common.py
+++ b/tests/test_testgres_common.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .helpers.global_data import OsOpsDescrs
+from .helpers.global_data import OsOpsDescr
 from .helpers.global_data import PostgresNodeService
 from .helpers.global_data import PostgresNodeServices
 from .helpers.global_data import OsOperations
@@ -16,6 +18,9 @@ from src.utils import get_pg_version2
 from src.utils import file_tail
 from src.utils import get_bin_path2
 from src.utils import execute_utility2
+from src.defaults import default_username
+from src.defaults import default_username2
+from src.config import testgres_config as tconf
 from src import ProcessType
 from src import NodeStatus
 from src import IsolationLevel
@@ -71,6 +76,25 @@ def removing(os_ops: OsOperations, f):
 
 
 class TestTestgresCommon:
+    sm_os_ops_descrs: typing.List[OsOpsDescr] = [
+        OsOpsDescrs.sm_local_os_ops_descr,
+        OsOpsDescrs.sm_remote_os_ops_descr
+    ]
+
+    @pytest.fixture(
+        params=[
+            pytest.param(
+                descr,
+                id=descr.sign,
+            )
+            for descr in sm_os_ops_descrs
+        ],
+    )
+    def os_ops_descr(self, request: pytest.FixtureRequest) -> OsOpsDescr:
+        assert isinstance(request, pytest.FixtureRequest)
+        assert isinstance(request.param, OsOpsDescr)
+        return request.param
+
     sm_node_svcs: typing.List[PostgresNodeService] = [
         PostgresNodeServices.sm_local,
         PostgresNodeServices.sm_local2,
@@ -132,6 +156,37 @@ class TestTestgresCommon:
             assert (isinstance(version, six.string_types))
             assert (isinstance(node.version, PgVer))
             assert (node.version == PgVer(version))
+
+    def test_default_username(
+        self,
+        os_ops_descr: OsOpsDescr,
+    ):
+        assert type(os_ops_descr) is OsOpsDescr
+        assert isinstance(os_ops_descr.os_ops, OsOperations)
+
+        os_ops = os_ops_descr.os_ops
+        assert isinstance(os_ops, OsOperations)
+
+        assert default_username(os_ops) == os_ops.get_user()
+        assert default_username(os_ops) == os_ops.username
+
+        assert default_username() == tconf.os_ops.username
+        assert default_username() == tconf.os_ops.get_user()
+        return
+
+    def test_default_username2(
+        self,
+        os_ops_descr: OsOpsDescr,
+    ):
+        assert type(os_ops_descr) is OsOpsDescr
+        assert isinstance(os_ops_descr.os_ops, OsOperations)
+
+        os_ops = os_ops_descr.os_ops
+        assert isinstance(os_ops, OsOperations)
+
+        assert default_username2(os_ops) == os_ops.get_user()
+        assert default_username2(os_ops) == os_ops.username
+        return
 
     def test_node_constructor__default(self):
         node = PostgresNode()


### PR DESCRIPTION
default_username:
 - new signature is: def default_username(os_ops: typing.Optional[OsOperations] = None) -> str:

new: default_username2 is added:
 - signature is: def default_username2(os_ops: OsOperations) -> str:

NodeConnection::\_\_init\_\_:
 - uses default_username2(node.os_ops)

Publication::\_\_init\_\_:
 - uses default_username2(node.os_ops)

Subscription::\_\_init\_\_:
 - uses default_username2(node.os_ops)

Amen.