### PR TITLE
CI: exact ruff version 0.15.22 is used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 flake8-pyproject ruff
+        python -m pip install flake8 flake8-pyproject ruff==0.15.22
     - name: Lint with flake8
       run: |
         flake8 .


### PR DESCRIPTION
Our source code has not ready for new ruff 0.16.1 yet.